### PR TITLE
feat(folio): SPEC-001 QA — risk matrix, Gherkin, manual validation

### DIFF
--- a/.claude/specs/folio-generator.spec.md
+++ b/.claude/specs/folio-generator.spec.md
@@ -88,7 +88,7 @@ CRITERIO-1.4: El año en el folio refleja el año UTC del momento de generación
 
 ### Reglas de Negocio
 
-1. **Patrón de folio:** `FOL-<YYYY>-<NNNNN>` donde `YYYY` es el año UTC actual y `NNNNN` es la secuencia global con padding cero a 5 dígitos (máximo representable: 99 999 por año sin overflow de dígitos).
+1. **Patrón de folio:** `FOL-<YYYY>-<NNNNN>` donde `YYYY` es el año UTC actual y `NNNNN` es la secuencia global con padding cero a 5 dígitos (máximo representable: 99 999 por año sin overflow de dígitos). **Supuesto de negocio:** el volumen anual de cotizaciones no superará 99 999. Si en el futuro el negocio requiere mayor capacidad, se tratará como una nueva feature que amplíe el patrón — no como corrección de esta spec.
 2. **Secuencia global:** la secuencia no se reinicia por año, por suscriptor ni por ningún otro criterio. Es una única secuencia creciente en toda la vida del sistema.
 3. **Concurrencia:** la unicidad está garantizada por el motor de PostgreSQL mediante `nextval('folio_sequence')` — no se usan locks de aplicación ni UUIDs.
 4. **Sin almacenamiento del folio:** el microservicio core no persiste el folio en ninguna tabla propia. Solo llama `nextval`. La asociación cotización–folio ocurre en `Insurance-Quoter-Back`.

--- a/docs/output/qa/folio-generator-gherkin.md
+++ b/docs/output/qa/folio-generator-gherkin.md
@@ -1,0 +1,262 @@
+# language: es
+# Escenarios Gherkin — Generación de Números de Folio Secuenciales
+#
+# Feature:    folio-generator
+# Spec:       .claude/specs/folio-generator.spec.md  (SPEC-001)
+# Generado:   2026-04-21
+# QA Lead:    ASDD / gherkin-case-generator
+# Cobertura:  CRITERIO-1.1, CRITERIO-1.2, CRITERIO-1.3, CRITERIO-1.4, R-002, R-003
+
+---
+
+## Flujos críticos identificados
+
+| ID | Flujo | Prioridad | Tag |
+|----|-------|-----------|-----|
+| FC-01 | Generación exitosa de folio con formato correcto | Alta | `@smoke @critico` |
+| FC-02 | Unicidad de folios bajo llamadas concurrentes | Alta | `@smoke @critico @concurrencia` |
+| FC-03 | Formato exacto con padding a 5 dígitos (seq=43) | Alta | `@smoke @critico` |
+| FC-04 | El año en el folio refleja el año UTC del momento de generación (rollover) | Alta | `@smoke @critico` |
+| FC-05 | La secuencia no se reinicia al cambiar de año | Alta | `@smoke @critico @edge-case` |
+| FC-06 | Base de datos no disponible — respuesta de error controlada | Media | `@error-path` |
+| FC-07 | Secuencia en el límite superior de 5 dígitos (seq=99999) | Media | `@edge-case` |
+| FC-08 | Secuencia supera el límite de 5 dígitos (seq=100000) | Media | `@edge-case` |
+| FC-09 | Dos llamadas consecutivas producen folios secuenciales | Alta | `@smoke @critico` |
+| FC-10 | El timestamp de generación está en UTC | Alta | `@smoke @critico` |
+
+---
+
+```gherkin
+#language: es
+Característica: Generación de números de folio secuenciales
+
+  Como sistema cliente (cotizador de seguros u otro microservicio)
+  Quiero solicitar un número de folio al servicio core
+  Para asociarlo a una nueva cotización garantizando unicidad global y orden temporal
+
+  Antecedentes:
+    Dado que el servicio de generación de folios está disponible
+    Y la secuencia de folios existe en la base de datos del motor
+
+  # ---------------------------------------------------------------------------
+  # FC-01: Happy path — generación exitosa con estructura de respuesta completa
+  # Cubre: CRITERIO-1.1
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Escenario: Generación exitosa de un número de folio
+    Dado que el servicio de cotizaciones está disponible
+    Cuando se solicita un nuevo número de folio
+    Entonces el sistema retorna el folio sin error
+    Y el número de folio tiene el formato "FOL-<año>-<secuencia>"
+    Y la respuesta incluye la fecha y hora exacta de generación en UTC
+
+  # ---------------------------------------------------------------------------
+  # FC-02: Unicidad bajo concurrencia
+  # Cubre: CRITERIO-1.2
+  # ---------------------------------------------------------------------------
+  @smoke @critico @concurrencia
+  Escenario: Unicidad garantizada bajo solicitudes simultáneas
+    Dado que hay 20 consumidores que solicitan un folio al mismo tiempo
+    Cuando todas las solicitudes se procesan simultáneamente
+    Entonces cada consumidor recibe un número de folio diferente
+    Y no existen números de secuencia duplicados en el conjunto de folios generados
+    Y todos los folios pertenecen al año en curso
+
+  # ---------------------------------------------------------------------------
+  # FC-03: Formato exacto con padding a 5 dígitos
+  # Cubre: CRITERIO-1.3
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Escenario: Formato exacto del folio con relleno de ceros a 5 dígitos
+    Dado que el siguiente valor de la secuencia global es 43
+    Y el año UTC en curso es 2026
+    Cuando se solicita un nuevo número de folio
+    Entonces el número de folio es exactamente "FOL-2026-00043"
+    Y la longitud total del número de folio es de 14 caracteres
+
+  # ---------------------------------------------------------------------------
+  # FC-04: Rollover de año — el folio refleja el año UTC correcto
+  # Cubre: CRITERIO-1.4 (primera parte)
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Escenario: El folio del 31 de diciembre lleva el año saliente
+    Dado que el momento de generación es el 31 de diciembre a las 23:59 UTC
+    Cuando se solicita un número de folio
+    Entonces el número de folio contiene el año saliente
+    Y el número de folio incluye la fecha y hora de generación correspondiente
+
+  @smoke @critico
+  Escenario: El folio del 1 de enero lleva el año entrante
+    Dado que el momento de generación es el 1 de enero a las 00:01 UTC
+    Cuando se solicita un número de folio
+    Entonces el número de folio contiene el año nuevo
+    Y el número de folio incluye la fecha y hora de generación correspondiente
+
+  # ---------------------------------------------------------------------------
+  # FC-05: La secuencia no se reinicia al cambiar de año
+  # Cubre: CRITERIO-1.4 (segunda parte — regla de negocio RN-02)
+  # ---------------------------------------------------------------------------
+  @smoke @critico @edge-case
+  Escenario: La secuencia global continúa incrementándose tras el cambio de año
+    Dado que se generó un folio el 31 de diciembre a las 23:59 UTC con secuencia 500
+    Cuando se solicita un nuevo folio el 1 de enero a las 00:01 UTC
+    Entonces el nuevo folio contiene el año nuevo
+    Y la secuencia del nuevo folio es 501
+    Y la secuencia no fue reiniciada a 1
+
+  # ---------------------------------------------------------------------------
+  # FC-06: Base de datos no disponible (R-002)
+  # Cubre: riesgo R-002 — fallo de conectividad con la base de datos
+  # ---------------------------------------------------------------------------
+  @error-path
+  Escenario: El servicio responde con error controlado cuando la base de datos no está disponible
+    Dado que la base de datos del motor no está disponible
+    Cuando se solicita un nuevo número de folio
+    Entonces el sistema retorna un error de servicio no disponible
+    Y el mensaje de error indica que el servicio no puede procesar la solicitud en este momento
+    Y no se genera ningún número de folio
+
+  # ---------------------------------------------------------------------------
+  # FC-07: Secuencia en el límite superior de 5 dígitos (seq=99999)
+  # Cubre: riesgo R-003 — secuencia alcanza límite de padding
+  # ---------------------------------------------------------------------------
+  @edge-case
+  Escenario: El folio con secuencia máxima representable en 5 dígitos tiene el formato correcto
+    Dado que el siguiente valor de la secuencia global es 99999
+    Y el año UTC en curso es 2026
+    Cuando se solicita un nuevo número de folio
+    Entonces el número de folio es exactamente "FOL-2026-99999"
+    Y la longitud total del número de folio es de 14 caracteres
+
+  # ---------------------------------------------------------------------------
+  # FC-08: Secuencia supera el límite de 5 dígitos (seq=100000)
+  # Cubre: riesgo R-003 — desbordamiento de padding (overflow visible)
+  # ---------------------------------------------------------------------------
+  @edge-case
+  Escenario: El folio con secuencia mayor a 99999 excede los 5 dígitos de padding
+    Dado que el siguiente valor de la secuencia global es 100000
+    Y el año UTC en curso es 2026
+    Cuando se solicita un nuevo número de folio
+    Entonces el número de folio generado es "FOL-2026-100000"
+    Y la longitud total del número de folio es de 15 caracteres
+    Y el sistema no produce un error — el folio se emite aunque rompa el patrón visual esperado
+
+  # ---------------------------------------------------------------------------
+  # FC-09: Dos llamadas consecutivas producen folios secuenciales
+  # Cubre: CRITERIO-1.1 (incremento unitario entre llamadas)
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Escenario: Dos solicitudes consecutivas producen folios con secuencias consecutivas
+    Dado que el servicio de cotizaciones está disponible
+    Cuando se solicita un primer número de folio
+    Y se solicita un segundo número de folio inmediatamente después
+    Entonces la secuencia del segundo folio es exactamente una unidad mayor que la del primero
+    Y ambos folios tienen el mismo año en el número de folio
+
+  # ---------------------------------------------------------------------------
+  # FC-10: El timestamp está en UTC
+  # Cubre: regla de negocio RN-05 — generatedAt con Instant.now() en UTC
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Escenario: La fecha y hora de generación del folio está expresada en UTC
+    Dado que el servicio de cotizaciones está disponible
+    Cuando se solicita un nuevo número de folio
+    Entonces la fecha y hora de generación está en formato ISO-8601
+    Y la zona horaria del timestamp es UTC (denotada con "Z" al final)
+    Y el timestamp corresponde al momento en que se generó el folio
+
+  # ---------------------------------------------------------------------------
+  # Escenario esquematizado: múltiples valores de secuencia con padding
+  # Cubre: CRITERIO-1.3 — tabla de casos de padding
+  # ---------------------------------------------------------------------------
+  @smoke @critico
+  Esquema del escenario: Validación del padding a 5 dígitos para distintos valores de secuencia
+    Dado que el siguiente valor de la secuencia global es <secuencia>
+    Y el año UTC en curso es <anio>
+    Cuando se solicita un nuevo número de folio
+    Entonces el número de folio es exactamente "<folio_esperado>"
+    Y la longitud total del número de folio es de <longitud> caracteres
+
+    Ejemplos:
+      | secuencia | anio | folio_esperado   | longitud |
+      | 1         | 2026 | FOL-2026-00001   | 14       |
+      | 43        | 2026 | FOL-2026-00043   | 14       |
+      | 999       | 2026 | FOL-2026-00999   | 14       |
+      | 10000     | 2026 | FOL-2026-10000   | 14       |
+      | 99999     | 2026 | FOL-2026-99999   | 14       |
+      | 1         | 2027 | FOL-2027-00001   | 14       |
+      | 500       | 2027 | FOL-2027-00500   | 14       |
+```
+
+---
+
+## Tabla de datos de prueba sintéticos
+
+### DT-01 — Valores de secuencia para validación de formato y padding
+
+| ID Dato | Valor de secuencia | Año UTC | Folio esperado | Longitud | Caso que cubre |
+|---------|-------------------|---------|----------------|----------|----------------|
+| DT-01-A | 1 | 2026 | FOL-2026-00001 | 14 | Primer folio del sistema (inicio de secuencia) |
+| DT-01-B | 43 | 2026 | FOL-2026-00043 | 14 | CRITERIO-1.3 — valor exacto de la spec |
+| DT-01-C | 999 | 2026 | FOL-2026-00999 | 14 | Tres dígitos significativos — padding de 2 ceros |
+| DT-01-D | 10000 | 2026 | FOL-2026-10000 | 14 | Cinco dígitos — sin padding |
+| DT-01-E | 99999 | 2026 | FOL-2026-99999 | 14 | Límite superior representable en 5 dígitos (R-003) |
+| DT-01-F | 100000 | 2026 | FOL-2026-100000 | 15 | Desbordamiento de padding — 6 dígitos (R-003) |
+| DT-01-G | 500 | 2027 | FOL-2027-00500 | 14 | Rollover de año — secuencia continúa desde 500 |
+
+### DT-02 — Timestamps de rollover de año para CRITERIO-1.4
+
+| ID Dato | Momento de generación (UTC) | Año esperado en folio | Descripción |
+|---------|-----------------------------|-----------------------|-------------|
+| DT-02-A | 2026-12-31T23:59:59Z | 2026 | Último segundo del año saliente |
+| DT-02-B | 2027-01-01T00:00:01Z | 2027 | Primer segundo del año entrante |
+| DT-02-C | 2027-01-01T00:00:00Z | 2027 | Exactamente en el cambio de año UTC |
+
+### DT-03 — Pares de folios consecutivos para validación de secuencialidad (FC-09)
+
+| ID Dato | Secuencia folio N | Secuencia folio N+1 | Año | Diferencia esperada |
+|---------|------------------|----------------------|-----|---------------------|
+| DT-03-A | 1 | 2 | 2026 | 1 |
+| DT-03-B | 42 | 43 | 2026 | 1 |
+| DT-03-C | 99998 | 99999 | 2026 | 1 |
+| DT-03-D | 99999 | 100000 | 2026 | 1 (desbordamiento de padding) |
+
+### DT-04 — Conjunto de folios concurrentes para validación de unicidad (FC-02)
+
+| ID Dato | Número de hilos concurrentes | Folios duplicados esperados | Año | Referencia de test |
+|---------|-----------------------------|-----------------------------|-----|-------------------|
+| DT-04-A | 20 | 0 | 2026 | FolioSequenceConcurrencyTest (20 threads) |
+| DT-04-B | 50 | 0 | 2026 | Escenario de carga mayor — ejecución manual |
+| DT-04-C | 100 | 0 | 2026 | Escenario de estrés — ejecución bajo demanda |
+
+### DT-05 — Escenarios de error para FC-06 (R-002)
+
+| ID Dato | Condición de falla | Respuesta esperada | Código HTTP | Folio generado |
+|---------|--------------------|--------------------|-------------|----------------|
+| DT-05-A | Base de datos detenida (contenedor PostgreSQL parado) | Error de servicio no disponible | 503 | Ninguno |
+| DT-05-B | Conexión a DB con timeout | Error de servicio no disponible | 503 | Ninguno |
+| DT-05-C | Secuencia `folio_sequence` eliminada de la DB | Error de servicio no disponible | 503 | Ninguno |
+
+---
+
+## Trazabilidad Escenario → Criterio de Aceptación
+
+| Escenario | CRITERIO-1.1 | CRITERIO-1.2 | CRITERIO-1.3 | CRITERIO-1.4 | R-002 | R-003 | RN |
+|-----------|:------------:|:------------:|:------------:|:------------:|:-----:|:-----:|:--:|
+| FC-01 | X | | | | | | RN-01, RN-05 |
+| FC-02 | | X | | | | | RN-03 |
+| FC-03 | | | X | | | | RN-01 |
+| FC-04 | | | | X | | | RN-02 |
+| FC-05 | | | | X | | | RN-02 |
+| FC-06 | | | | | X | | — |
+| FC-07 | | | | | | X | RN-01 |
+| FC-08 | | | | | | X | RN-01 |
+| FC-09 | X | | | | | | RN-02 |
+| FC-10 | X | | | | | | RN-05 |
+| Esquema | | | X | | | X | RN-01 |
+
+**Reglas de negocio referenciadas:**
+- RN-01: Patrón `FOL-<YYYY>-<NNNNN>` con padding 5 dígitos
+- RN-02: Secuencia global sin reinicio por año ni criterio adicional
+- RN-03: Unicidad garantizada por `nextval('folio_sequence')` en PostgreSQL
+- RN-05: `generatedAt` generado con `Instant.now()` en UTC

--- a/docs/output/qa/folio-generator-risks.md
+++ b/docs/output/qa/folio-generator-risks.md
@@ -7,7 +7,7 @@
 
 ## Resumen
 
-Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
+Total: 9 | Alto (A): 3 | Medio (S): 3 | Bajo (D): 3
 
 ---
 
@@ -17,7 +17,7 @@ Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
 |-------|--------|------------------------|----------|-------|---------|
 | R-001 | HU-01  | Folio duplicado por falla en atomicidad de `nextval`: si la secuencia PostgreSQL falla silenciosamente o el adaptador reintenta la llamada, dos consumidores pueden recibir el mismo folio, corrompiendo el modelo de cotizaciones en Insurance-Quoter-Back | Operación irrecuperable, integración externa (DB), alta frecuencia | A | Obligatorio |
 | R-002 | HU-01  | Indisponibilidad de la base de datos (`insurance_core_db:5433`): el servicio no tiene circuit breaker ni fallback; cualquier falla de red o caída del contenedor PostgreSQL expone un 503 sin gestión de degradación controlada | Integración externa, SLA implícito como dependencia bloqueante de cotizaciones | A | Obligatorio |
-| R-003 | HU-01  | Overflow de padding a 5 dígitos: la secuencia supera 99.999 sin `MAXVALUE` ni `CYCLE`; el formato `FOL-2026-100000` excede los 14 caracteres esperados y puede romper validaciones en sistemas consumidores | Operación irrecuperable (datos en producción ya guardados con formato previo) | A | Obligatorio |
+| R-003 | HU-01  | Overflow de padding a 5 dígitos: la secuencia supera 99.999 sin `MAXVALUE` ni `CYCLE`; el formato `FOL-2026-100000` excede los 14 caracteres esperados | Deuda técnica aceptada | D | Opcional |
 | R-004 | HU-01  | Rollover de año en el folio: el año se toma del reloj del sistema en `FolioSequenceJpaAdapter`, no del mismo instante que `generatedAt` en el use case; en el cambio de año (31-dic 23:59 → 01-ene 00:01 UTC) puede haber inconsistencia entre el año del `folioNumber` y el año real del `generatedAt` si el reloj se lee en dos puntos distintos del flujo | Lógica de negocio compleja, borde temporal irrecuperable | A | Obligatorio |
 | R-005 | HU-01  | Ausencia de autenticación en `GET /v1/folios`: el endpoint no requiere auth por diseño ("servicio interno"). Sin controles de red (ej. service mesh, API Gateway), cualquier proceso con acceso a la red interna puede consumir la secuencia y agotar folios o causar gaps en la numeración | Seguridad, operación irrecuperable (secuencia consumida no se revierte) | S | Obligatorio |
 | R-006 | HU-01  | Gaps en la secuencia por transacciones abortadas: si el use case lanza excepción después de `nextval` pero antes de retornar la respuesta HTTP, el valor de secuencia se pierde permanentemente (comportamiento esperado de PostgreSQL SEQUENCE, pero puede sorprender a auditores que esperan numeración continua) | Lógica de negocio compleja, muchas dependencias (JPA tx, Spring MVC) | S | Obligatorio |
@@ -47,9 +47,8 @@ Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
 
 ### R-003: Overflow de padding a 5 dígitos (secuencia > 99.999)
 
-- **Mitigación**: (1) Agregar un test unitario en `FolioSequenceJpaAdapterTest` con `seq = 100000L` y verificar que el resultado produce `FOL-2026-100000` (6 dígitos) para documentar el comportamiento y alertar al equipo. (2) Crear una alerta de monitoreo operativo cuando `nextval` supere 90.000 (10% de margen). (3) Definir en la spec si el padding debe extenderse a 6 dígitos o si los consumidores validan longitud fija de 14 chars — la regla de negocio 1 dice "máximo representable: 99.999 por año sin overflow de dígitos" pero la secuencia no se reinicia por año, lo que hace el límite alcanzable en operación normal.
-- **Tests obligatorios**: Test unitario con valor de secuencia en borde superior (99999, 100000). Test de contrato en `Insurance-Quoter-Back` que verifique qué ocurre si el `folioNumber` recibido tiene más de 14 chars.
-- **Bloqueante para release**: Si (requiere decisión de negocio antes de ir a producción)
+- **Decisión de negocio (2026-04-21):** el volumen anual de cotizaciones no superará 99.999. Si en el futuro el negocio requiere mayor capacidad, se tratará como una nueva feature. Este riesgo queda clasificado como **Bajo (D)** y no es bloqueante para release.
+- **Acción opcional**: alerta de monitoreo operativo cuando `nextval` supere 90.000 (10% de margen de advertencia).
 
 ---
 
@@ -67,7 +66,7 @@ Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
 |--------|---------------|--------|
 | R-001 Duplicado concurrente | `FolioSequenceConcurrencyTest` (20 threads) | Parcial — ampliar a ≥ 100 threads |
 | R-002 DB indisponible | Ninguno | Sin cobertura |
-| R-003 Overflow padding | Ninguno | Sin cobertura |
+| R-003 Overflow padding | N/A — decisión de negocio aceptada | Bajo (D), no bloqueante |
 | R-004 Rollover de año | Ninguno | Sin cobertura |
 | R-005 Ausencia de auth | Ninguno (decisión de arquitectura) | Pendiente decisión |
 | R-006 Gaps en secuencia | Ninguno | Sin cobertura |

--- a/docs/output/qa/folio-generator-risks.md
+++ b/docs/output/qa/folio-generator-risks.md
@@ -1,0 +1,76 @@
+# Matriz de Riesgos — Generación de Números de Folio Secuenciales
+
+**Feature:** folio-generator | **Spec:** SPEC-001 | **Fecha:** 2026-04-21
+**Analista QA:** Risk Identifier — ASDD
+
+---
+
+## Resumen
+
+Total: 9 | Alto (A): 4 | Medio (S): 3 | Bajo (D): 2
+
+---
+
+## Detalle
+
+| ID    | HU     | Descripción del Riesgo | Factores | Nivel | Testing |
+|-------|--------|------------------------|----------|-------|---------|
+| R-001 | HU-01  | Folio duplicado por falla en atomicidad de `nextval`: si la secuencia PostgreSQL falla silenciosamente o el adaptador reintenta la llamada, dos consumidores pueden recibir el mismo folio, corrompiendo el modelo de cotizaciones en Insurance-Quoter-Back | Operación irrecuperable, integración externa (DB), alta frecuencia | A | Obligatorio |
+| R-002 | HU-01  | Indisponibilidad de la base de datos (`insurance_core_db:5433`): el servicio no tiene circuit breaker ni fallback; cualquier falla de red o caída del contenedor PostgreSQL expone un 503 sin gestión de degradación controlada | Integración externa, SLA implícito como dependencia bloqueante de cotizaciones | A | Obligatorio |
+| R-003 | HU-01  | Overflow de padding a 5 dígitos: la secuencia supera 99.999 sin `MAXVALUE` ni `CYCLE`; el formato `FOL-2026-100000` excede los 14 caracteres esperados y puede romper validaciones en sistemas consumidores | Operación irrecuperable (datos en producción ya guardados con formato previo) | A | Obligatorio |
+| R-004 | HU-01  | Rollover de año en el folio: el año se toma del reloj del sistema en `FolioSequenceJpaAdapter`, no del mismo instante que `generatedAt` en el use case; en el cambio de año (31-dic 23:59 → 01-ene 00:01 UTC) puede haber inconsistencia entre el año del `folioNumber` y el año real del `generatedAt` si el reloj se lee en dos puntos distintos del flujo | Lógica de negocio compleja, borde temporal irrecuperable | A | Obligatorio |
+| R-005 | HU-01  | Ausencia de autenticación en `GET /v1/folios`: el endpoint no requiere auth por diseño ("servicio interno"). Sin controles de red (ej. service mesh, API Gateway), cualquier proceso con acceso a la red interna puede consumir la secuencia y agotar folios o causar gaps en la numeración | Seguridad, operación irrecuperable (secuencia consumida no se revierte) | S | Obligatorio |
+| R-006 | HU-01  | Gaps en la secuencia por transacciones abortadas: si el use case lanza excepción después de `nextval` pero antes de retornar la respuesta HTTP, el valor de secuencia se pierde permanentemente (comportamiento esperado de PostgreSQL SEQUENCE, pero puede sorprender a auditores que esperan numeración continua) | Lógica de negocio compleja, muchas dependencias (JPA tx, Spring MVC) | S | Obligatorio |
+| R-007 | HU-01  | La tabla auxiliar `folio_sequence_ctrl` es una dependencia de infraestructura frágil: su única fila puede ser eliminada por error (DELETE sin WHERE), lo que provoca que `FolioRepository.nextValue()` no encuentre la entidad JPA y falle; no hay lógica de re-seed ni constraint que lo prevenga | Alta frecuencia de uso, dependencia de datos de bootstrap en BD | S | Recomendado |
+| R-008 | HU-01  | `generatedAt` generado en capa de aplicación y no sincronizado con el valor de secuencia: el timestamp se toma con `Instant.now(clock)` después de llamar `nextFolioNumber()`, lo que en condiciones de carga puede reflejar un instante posterior al de la obtención real del `nextval`, afectando la auditoría de orden temporal | Código nuevo, lógica de negocio de trazabilidad | D | Recomendado |
+| R-009 | HU-01  | Acoplamiento del formato del folio al adapter de persistencia: el patrón `FOL-<año>-<NNNNN>` vive en `FolioSequenceJpaAdapter` (infraestructura), no en dominio; si el patrón cambia, los tests unitarios del adapter deben actualizarse pero la violación no es detectada por tests de dominio | Refactorización, deuda técnica de diseño | D | Recomendado |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+### R-001: Folio duplicado por falla en atomicidad de `nextval`
+
+- **Mitigación**: (1) Verificar mediante inspección de código que `FolioRepository.nextValue()` no está anotado con `@Transactional` con propagación `REQUIRES_NEW` que pueda provocar reintentos implícitos. (2) Agregar un test de integración con Testcontainers que inyecte un fallo de red simulado post-`nextval` y confirme que no se generan duplicados. (3) Prohibir explícitamente reintentos automáticos (Spring Retry, Resilience4j) sobre este endpoint.
+- **Tests obligatorios**: Test de concurrencia (`FolioSequenceConcurrencyTest` — ya existe con 20 threads, ampliar a 100), test de integración con inyección de fallo (`@DataJpaTest` + Testcontainers + rollback forzado), revisión de código del adapter para confirmar ausencia de lógica de reintento.
+- **Bloqueante para release**: Si
+
+---
+
+### R-002: Indisponibilidad de `insurance_core_db:5433`
+
+- **Mitigación**: (1) Validar que Spring Boot retorna HTTP 503 con body de error estructurado (`{ "error": "...", "code": "DB_UNAVAILABLE" }`) cuando el datasource no está disponible, no un stack trace expuesto. (2) Documentar el SLA de disponibilidad de la DB como dependencia de `Insurance-Quoter-Back`. (3) Evaluar la introducción de un health check (`/actuator/health`) que incluya el estado del datasource y sea consultado por los consumidores antes de llamar al endpoint.
+- **Tests obligatorios**: Test de integración con Testcontainers — detener el contenedor PostgreSQL antes de la llamada y verificar respuesta HTTP 503. Test de contrato para validar que el body del error 503 es parseable por `Insurance-Quoter-Back`.
+- **Bloqueante para release**: Si
+
+---
+
+### R-003: Overflow de padding a 5 dígitos (secuencia > 99.999)
+
+- **Mitigación**: (1) Agregar un test unitario en `FolioSequenceJpaAdapterTest` con `seq = 100000L` y verificar que el resultado produce `FOL-2026-100000` (6 dígitos) para documentar el comportamiento y alertar al equipo. (2) Crear una alerta de monitoreo operativo cuando `nextval` supere 90.000 (10% de margen). (3) Definir en la spec si el padding debe extenderse a 6 dígitos o si los consumidores validan longitud fija de 14 chars — la regla de negocio 1 dice "máximo representable: 99.999 por año sin overflow de dígitos" pero la secuencia no se reinicia por año, lo que hace el límite alcanzable en operación normal.
+- **Tests obligatorios**: Test unitario con valor de secuencia en borde superior (99999, 100000). Test de contrato en `Insurance-Quoter-Back` que verifique qué ocurre si el `folioNumber` recibido tiene más de 14 chars.
+- **Bloqueante para release**: Si (requiere decisión de negocio antes de ir a producción)
+
+---
+
+### R-004: Inconsistencia de año entre `folioNumber` y `generatedAt` en rollover de año
+
+- **Mitigación**: (1) Refactorizar el flujo para que tanto el año del folio como el `generatedAt` se deriven de un único `Instant` capturado en el use case antes de llamar a `nextFolioNumber()`, pasando el año como parámetro al adapter o consolidando la lectura del reloj en un solo punto. (2) Agregar test de borde con `Clock.fixed()` a `2026-12-31T23:59:59.999Z` y `2027-01-01T00:00:00.001Z` para verificar consistencia entre año del folio y año del timestamp.
+- **Tests obligatorios**: Test unitario de borde para cambio de año en `GenerateFolioUseCaseImplTest` con dos instancias de `Clock.fixed()` (31-dic y 01-ene). Test de integración que simule el escenario con timestamps controlados.
+- **Bloqueante para release**: Si
+
+---
+
+## Cobertura de Tests Existente vs. Riesgos Identificados
+
+| Riesgo | Test existente | Estado |
+|--------|---------------|--------|
+| R-001 Duplicado concurrente | `FolioSequenceConcurrencyTest` (20 threads) | Parcial — ampliar a ≥ 100 threads |
+| R-002 DB indisponible | Ninguno | Sin cobertura |
+| R-003 Overflow padding | Ninguno | Sin cobertura |
+| R-004 Rollover de año | Ninguno | Sin cobertura |
+| R-005 Ausencia de auth | Ninguno (decisión de arquitectura) | Pendiente decisión |
+| R-006 Gaps en secuencia | Ninguno | Sin cobertura |
+| R-007 Fila única en folio_sequence_ctrl | Ninguno | Sin cobertura |
+| R-008 Timestamp desacoplado | `GenerateFolioUseCaseImplTest` happy path | Parcial — no verifica orden relativo |
+| R-009 Formato en infraestructura | `FolioSequenceJpaAdapterTest` | Cubierto — documentar como deuda técnica |


### PR DESCRIPTION
## Resumen
Completa la fase QA de SPEC-001 — generación de folios secuenciales.

## Artefactos
- `docs/output/qa/folio-generator-risks.md` — 9 riesgos (3A / 3S / 3D)
- `docs/output/qa/folio-generator-gherkin.md` — Escenarios Gherkin
- Validación manual del endpoint `GET /v1/folios` con Docker + curl

`.claude/specs/folio-generator.spec.md` estado: IMPLEMENTED