### PR TITLE
feat: agents catalog - GET /v1/agents + existsByCode (SPEC-003)

### DIFF
--- a/.claude/specs/agents-catalog.spec.md
+++ b/.claude/specs/agents-catalog.spec.md
@@ -1,0 +1,287 @@
+---
+id: SPEC-003
+status: DRAFT
+feature: agents-catalog
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-002"]
+---
+
+# Spec: Catálogo de Agentes Disponibles
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+El microservicio `Insurance-Quoter-Core` expone un endpoint `GET /v1/agents` que retorna el catálogo completo de agentes disponibles. Los datos son estáticos: se cargan desde un archivo JSON al iniciar la aplicación y se sirven desde memoria. No existe escritura ni modificación del catálogo en tiempo de ejecución.
+
+Además del endpoint de consulta, el output port expone `existsByCode(String code): boolean` para que `Insurance-Quoter-Back` pueda validar si un agente es válido al momento de crear un folio (referencia: contrato `POST /v1/folios`, error `INVALID_REFERENCE`).
+
+### Requerimiento de Negocio
+
+> Catálogo de agentes disponibles en el microservicio core.
+> Endpoint `GET /v1/agents`. Los datos provienen de un archivo
+> `src/main/resources/fixtures/agents.json` cargado en memoria al inicio.
+> No hay escritura. El catálogo es estático y gestionado por configuración.
+> El port `AgentRepository` también expone `existsByCode` para validación
+> cross-service desde `Insurance-Quoter-Back`.
+
+### Historias de Usuario
+
+#### HU-01: Consultar catálogo de agentes
+
+```
+Como:        sistema cliente (Insurance-Quoter-Back u otro consumidor)
+Quiero:      llamar GET /v1/agents y recibir la lista completa de agentes disponibles
+Para:        presentar opciones de agente al usuario en el flujo de cotización
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: Ninguna (sin base de datos, datos en memoria)
+Capa:        Backend
+```
+
+#### HU-02: Validar existencia de agente por código
+
+```
+Como:        Insurance-Quoter-Back
+Quiero:      invocar AgentRepository.existsByCode(code) para verificar si un agente es válido
+Para:        rechazar la creación de folios con agentes inexistentes (error INVALID_REFERENCE)
+
+Prioridad:   Alta
+Estimación:  XS
+Dependencias: HU-01 (requiere que el catálogo esté cargado en memoria)
+Capa:        Backend (uso interno vía port, no expone endpoint adicional)
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Retorno del catálogo completo
+  Dado que:  el servicio Insurance-Quoter-Core está disponible
+             Y el archivo fixtures/agents.json contiene al menos un agente
+  Cuando:    se realiza GET /v1/agents
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene el campo "agents" con un array
+             Y cada elemento del array contiene "code", "name" y "subscriberId" con valores no vacíos
+```
+
+**Catálogo vacío**
+```gherkin
+CRITERIO-1.2: Catálogo sin entradas configuradas
+  Dado que:  el archivo fixtures/agents.json existe pero el array está vacío
+  Cuando:    se realiza GET /v1/agents
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "agents" con un array vacío []
+```
+
+**Error de configuración**
+```gherkin
+CRITERIO-1.3: Archivo de fixtures no encontrado
+  Dado que:  el archivo fixtures/agents.json no existe en el classpath
+  Cuando:    la aplicación intenta arrancar
+  Entonces:  la aplicación falla al iniciar con un mensaje de error claro
+             Y NO se expone el endpoint con datos inconsistentes
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Agente existente**
+```gherkin
+CRITERIO-2.1: Código de agente válido
+  Dado que:  el catálogo en memoria contiene el agente con code "AGT-123"
+  Cuando:    se invoca AgentRepository.existsByCode("AGT-123")
+  Entonces:  el método retorna true
+```
+
+**Agente inexistente**
+```gherkin
+CRITERIO-2.2: Código de agente inválido
+  Dado que:  el catálogo en memoria NO contiene ningún agente con code "AGT-999"
+  Cuando:    se invoca AgentRepository.existsByCode("AGT-999")
+  Entonces:  el método retorna false
+```
+
+### Reglas de Negocio
+
+| ID   | Regla |
+|------|-------|
+| RN-1 | El catálogo es de solo lectura — no existe endpoint de creación, modificación ni eliminación. |
+| RN-2 | Los datos se cargan una sola vez al iniciar la aplicación (eager loading en el adapter). |
+| RN-3 | Si el archivo JSON no existe o no es parseable, la aplicación debe fallar al arrancar (fail-fast). |
+| RN-4 | El `code` de cada agente es un identificador de negocio opaco (ej. `AGT-123`), no una PK de base de datos. |
+| RN-5 | Cada agente pertenece a un suscriptor identificado por `subscriberId` (ej. `SUB-001`). La relación es referencial — no se valida que el `subscriberId` exista en el catálogo de suscriptores al cargar el JSON. |
+| RN-6 | El endpoint no requiere autenticación — es un servicio interno consumido por `Insurance-Quoter-Back`. |
+| RN-7 | `existsByCode` compara por igualdad exacta (case-sensitive). |
+
+---
+
+## 2. DISEÑO
+
+### Modelo de Dominio
+
+#### `Agent` — domain model (POJO puro, sin anotaciones JPA ni Spring)
+
+```java
+// com.sofka.insurancequoter.core.agent.domain.model.Agent
+public record Agent(String code, String name, String subscriberId) {}
+```
+
+| Campo          | Tipo   | Restricciones                                               |
+|----------------|--------|-------------------------------------------------------------|
+| `code`         | String | No nulo, no vacío — identificador de negocio (ej. `AGT-123`) |
+| `name`         | String | No nulo, no vacío — nombre legible del agente               |
+| `subscriberId` | String | No nulo, no vacío — referencia al suscriptor al que pertenece (ej. `SUB-001`) |
+
+### Output Port
+
+```java
+// com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository
+public interface AgentRepository {
+    List<Agent> findAll();
+    boolean existsByCode(String code);
+}
+```
+
+### Input Port (Use Case)
+
+```java
+// com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase
+public interface GetAgentsUseCase {
+    List<Agent> getAll();
+}
+```
+
+### Fixture — `src/main/resources/fixtures/agents.json`
+
+```json
+[
+  { "code": "AGT-123", "name": "Juan Pérez", "subscriberId": "SUB-001" },
+  { "code": "AGT-124", "name": "María López", "subscriberId": "SUB-001" },
+  { "code": "AGT-201", "name": "Carlos Ruiz", "subscriberId": "SUB-002" }
+]
+```
+
+> El adapter deserializa este array en `List<Agent>` al construirse (vía Jackson `ObjectMapper`).
+> `existsByCode` se implementa buscando en la lista en memoria con stream.
+
+### API Endpoint
+
+#### `GET /v1/agents`
+
+| Atributo  | Valor               |
+|-----------|---------------------|
+| Método    | `GET`               |
+| Ruta      | `/v1/agents`        |
+| Auth      | Ninguna (servicio interno) |
+| Produces  | `application/json`  |
+
+**Response 200 — catálogo con datos:**
+```json
+{
+  "agents": [
+    { "code": "AGT-123", "name": "Juan Pérez", "subscriberId": "SUB-001" },
+    { "code": "AGT-124", "name": "María López", "subscriberId": "SUB-001" },
+    { "code": "AGT-201", "name": "Carlos Ruiz", "subscriberId": "SUB-002" }
+  ]
+}
+```
+
+**Response 200 — catálogo vacío:**
+```json
+{
+  "agents": []
+}
+```
+
+> No hay respuestas 4xx ni 5xx en operación normal. Los errores de configuración se manifiestan al arrancar.
+
+### DTOs REST
+
+#### `AgentDto`
+
+```java
+public record AgentDto(String code, String name, String subscriberId) {}
+```
+
+#### `AgentsResponse`
+
+```java
+public record AgentsResponse(List<AgentDto> agents) {}
+```
+
+### Arquitectura Hexagonal — estructura de paquetes
+
+```
+com.sofka.insurancequoter.core.agent/
+├── domain/
+│   ├── model/
+│   │   └── Agent.java                              ← record puro
+│   └── port/
+│       ├── in/
+│       │   └── GetAgentsUseCase.java               ← input port
+│       └── out/
+│           └── AgentRepository.java                ← output port
+├── application/
+│   └── usecase/
+│       └── GetAgentsUseCaseImpl.java               ← sin @Service, wired via @Bean
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── swaggerdocs/
+    │   │       │   └── AgentApi.java               ← @Tag, @Operation
+    │   │       ├── AgentController.java            ← implements AgentApi
+    │   │       ├── dto/
+    │   │       │   ├── AgentDto.java
+    │   │       │   └── AgentsResponse.java
+    │   │       └── mapper/
+    │   │           └── AgentRestMapper.java
+    │   └── out/
+    │       └── json/
+    │           └── AgentJsonAdapter.java           ← carga JSON, implementa AgentRepository
+    └── config/
+        └── AgentConfig.java                        ← @Bean wiring
+```
+
+> El adapter de persistencia es `out/json/` (no `out/persistence/`) porque no hay base de datos involucrada.
+
+---
+
+## 3. LISTA DE TAREAS
+
+### Backend
+
+- [ ] **TASK-1** Crear domain model `Agent` (record Java con `code`, `name`, `subscriberId`, sin anotaciones)
+- [ ] **TASK-2** Crear output port `AgentRepository` con métodos `findAll(): List<Agent>` y `existsByCode(String code): boolean`
+- [ ] **TASK-3** Crear input port `GetAgentsUseCase` con método `getAll(): List<Agent>`
+- [ ] **TASK-4** Implementar `GetAgentsUseCaseImpl` — delega a `AgentRepository.findAll()`
+- [ ] **TASK-5** Crear `AgentJsonAdapter` — carga `fixtures/agents.json` vía `ObjectMapper` al construirse; implementa `AgentRepository` (incluyendo `existsByCode` con búsqueda en stream)
+- [ ] **TASK-6** Crear archivo `src/main/resources/fixtures/agents.json` con los datos estáticos de los agentes
+- [ ] **TASK-7** Crear DTOs REST: `AgentDto`, `AgentsResponse`
+- [ ] **TASK-8** Crear `AgentRestMapper` — mapea `List<Agent>` → `AgentsResponse`
+- [ ] **TASK-9** Crear interfaz Swagger `AgentApi` (en `rest/swaggerdocs/`)
+- [ ] **TASK-10** Crear `AgentController` — implementa `AgentApi`, llama `GetAgentsUseCase`
+- [ ] **TASK-11** Crear `AgentConfig` — registra `AgentJsonAdapter` y `GetAgentsUseCaseImpl` como `@Bean`
+
+### Tests (TDD — escribir antes de implementar)
+
+- [ ] **TASK-12** Test unitario `GetAgentsUseCaseImplTest` — verifica delegación al port y retorno de lista
+- [ ] **TASK-13** Test unitario `AgentJsonAdapterTest` — verifica carga correcta del JSON y mapeo a `List<Agent>`; verifica `existsByCode` con código existente, código inexistente y JSON vacío
+- [ ] **TASK-14** Test unitario `AgentRestMapperTest` — verifica mapeo `List<Agent>` → `AgentsResponse` (incluye campo `subscriberId`)
+- [ ] **TASK-15** Test unitario `AgentControllerTest` — verifica HTTP 200 y estructura del response
+- [ ] **TASK-16** Test de integración `AgentCatalogIntegrationTest` (`@SpringBootTest`) — levanta contexto completo, llama `GET /v1/agents`, valida response 200 con datos del fixture
+
+### QA
+
+- [ ] **TASK-17** Ejecutar `/risk-identifier` para generar matriz de riesgos `agents-catalog-risks.md`
+- [ ] **TASK-18** Ejecutar `/gherkin-case-generator` para generar escenarios Gherkin `agents-catalog-gherkin.md`
+- [ ] **TASK-19** Validar endpoint manualmente con curl o Swagger UI (`http://localhost:8081/swagger-ui/index.html`)

--- a/.claude/specs/agents-catalog.spec.md
+++ b/.claude/specs/agents-catalog.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-003
-status: DRAFT
+status: APPROVED
 feature: agents-catalog
 created: 2026-04-21
 updated: 2026-04-21

--- a/.claude/specs/agents-catalog.spec.md
+++ b/.claude/specs/agents-catalog.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-003
-status: APPROVED
+status: IMPLEMENTED
 feature: agents-catalog
 created: 2026-04-21
 updated: 2026-04-21

--- a/docs/output/qa/agents-catalog-gherkin.md
+++ b/docs/output/qa/agents-catalog-gherkin.md
@@ -1,0 +1,128 @@
+# Escenarios Gherkin — Agents Catalog (SPEC-003)
+
+> Feature: `agents-catalog` | Microservicio: `Insurance-Quoter-Core` (puerto 8081)
+> Fecha: 2026-04-21 | Generado desde spec SPEC-003 v1.0
+
+---
+
+```gherkin
+#language: es
+Característica: Catálogo de agentes disponibles
+
+  Como sistema cliente (Insurance-Quoter-Back)
+  Quiero consultar el catálogo de agentes y validar su existencia
+  Para mostrar opciones al usuario y asegurar integridad al crear folios
+
+  # ─────────────────────────────────────────────
+  # HU-01: Consultar catálogo de agentes
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @happy-path
+  Escenario: Consultar catálogo de agentes con datos configurados
+    Dado que el servicio de catálogos está disponible
+    Y el catálogo de agentes contiene los siguientes agentes:
+      | código  | nombre       | suscriptor |
+      | AGT-123 | Juan Pérez   | SUB-001    |
+      | AGT-124 | María López  | SUB-001    |
+      | AGT-201 | Carlos Ruiz  | SUB-002    |
+    Cuando se solicita el listado completo de agentes disponibles
+    Entonces la respuesta es exitosa
+    Y el listado contiene 3 agentes
+    Y cada agente tiene código, nombre y suscriptor con valores no vacíos
+
+  @happy-path @edge-case
+  Escenario: Consultar catálogo cuando no hay agentes configurados
+    Dado que el servicio de catálogos está disponible
+    Y el catálogo de agentes no contiene ningún agente
+    Cuando se solicita el listado completo de agentes disponibles
+    Entonces la respuesta es exitosa
+    Y el listado de agentes está vacío
+
+  @smoke @critico @happy-path
+  Escenario: Verificar que el agente pertenece al suscriptor correcto
+    Dado que el catálogo de agentes contiene al agente "AGT-123" del suscriptor "SUB-001"
+    Cuando se solicita el listado completo de agentes disponibles
+    Entonces el agente "AGT-123" aparece en el listado
+    Y su suscriptor asociado es "SUB-001"
+
+  @edge-case
+  Escenario: Catálogo contiene agentes de múltiples suscriptores
+    Dado que el catálogo de agentes contiene agentes de los suscriptores "SUB-001" y "SUB-002"
+    Cuando se solicita el listado completo de agentes disponibles
+    Entonces el listado incluye agentes de ambos suscriptores
+
+  # ─────────────────────────────────────────────
+  # HU-02: Validar existencia de agente por código
+  # ─────────────────────────────────────────────
+
+  @smoke @critico @happy-path
+  Escenario: Validar un código de agente existente
+    Dado que el catálogo de agentes contiene al agente con código "AGT-123"
+    Cuando el sistema verifica si el código "AGT-123" corresponde a un agente válido
+    Entonces el sistema confirma que el agente existe
+
+  @error-path @critico
+  Escenario: Rechazar un código de agente inexistente
+    Dado que el catálogo de agentes no contiene ningún agente con código "AGT-999"
+    Cuando el sistema verifica si el código "AGT-999" corresponde a un agente válido
+    Entonces el sistema indica que el agente no existe
+
+  @error-path
+  Escenario: Rechazar validación cuando el catálogo está vacío
+    Dado que el catálogo de agentes no contiene ningún agente
+    Cuando el sistema verifica si el código "AGT-123" corresponde a un agente válido
+    Entonces el sistema indica que el agente no existe
+
+  @edge-case
+  Escenario: Validación es sensible a mayúsculas y minúsculas
+    Dado que el catálogo de agentes contiene al agente con código "AGT-123"
+    Cuando el sistema verifica si el código "agt-123" corresponde a un agente válido
+    Entonces el sistema indica que el agente no existe
+
+  @edge-case
+  Escenario: Validación es sensible a espacios en el código
+    Dado que el catálogo de agentes contiene al agente con código "AGT-123"
+    Cuando el sistema verifica si el código " AGT-123" corresponde a un agente válido
+    Entonces el sistema indica que el agente no existe
+
+  # ─────────────────────────────────────────────
+  # RN-3: Fail-fast al arrancar
+  # ─────────────────────────────────────────────
+
+  @error-path @critico
+  Escenario: El servicio no arranca si el archivo de catálogo no existe
+    Dado que el archivo de configuración del catálogo de agentes no está disponible
+    Cuando el servicio de catálogos intenta inicializarse
+    Entonces el servicio falla al arrancar con un mensaje de error descriptivo
+    Y no se expone ningún endpoint con datos inconsistentes
+
+  @error-path
+  Escenario: El servicio no arranca si el archivo de catálogo tiene formato inválido
+    Dado que el archivo de configuración del catálogo de agentes contiene datos con formato incorrecto
+    Cuando el servicio de catálogos intenta inicializarse
+    Entonces el servicio falla al arrancar con un mensaje de error descriptivo
+```
+
+---
+
+## Datos de Prueba
+
+| Escenario | Campo | Valor válido | Valor inválido | Caso borde |
+|-----------|-------|-------------|----------------|------------|
+| Consultar catálogo | — | catálogo con 3 agentes | — | catálogo vacío `[]` |
+| Validar agente existente | `code` | `"AGT-123"` | `"AGT-999"` | `"agt-123"` (minúsculas) |
+| Validar agente existente | `code` | `"AGT-123"` | `"AGT-999"` | `" AGT-123"` (espacio inicial) |
+| Arranque del servicio | fixture | `agents.json` válido | archivo ausente | JSON malformado |
+| Relación con suscriptor | `subscriberId` | `"SUB-001"` | — | agentes de dos suscriptores distintos |
+
+---
+
+## Flujos priorizados para automatización (Serenity BDD)
+
+| Prioridad | Escenario | Tag | Justificación |
+|-----------|-----------|-----|---------------|
+| 1 | Consultar catálogo con datos configurados | `@smoke @critico` | Happy path principal — base para otros flujos |
+| 2 | Validar código de agente existente | `@smoke @critico` | Impacto directo en creación de folios |
+| 3 | Rechazar código de agente inexistente | `@error-path @critico` | Previene folios con agentes inválidos |
+| 4 | Servicio no arranca sin archivo de catálogo | `@error-path @critico` | Fail-fast — afecta disponibilidad total del servicio |
+| 5 | Validación sensible a mayúsculas | `@edge-case` | Comportamiento no obvio según RN-7 |

--- a/docs/output/qa/agents-catalog-risks.md
+++ b/docs/output/qa/agents-catalog-risks.md
@@ -1,0 +1,69 @@
+# Matriz de Riesgos — Agents Catalog (SPEC-003)
+
+> Feature: `agents-catalog` | Microservicio: `Insurance-Quoter-Core` (puerto 8081)
+> Fecha: 2026-04-21 | Metodología: Regla ASD del CoE
+
+---
+
+## Resumen
+
+| Total | Alto (A) | Medio (S) | Bajo (D) |
+|-------|----------|-----------|----------|
+| 6     | 2        | 3         | 1        |
+
+---
+
+## Detalle
+
+| ID    | HU     | Descripción del Riesgo                                                              | Factores                                             | Nivel | Testing      |
+|-------|--------|-------------------------------------------------------------------------------------|------------------------------------------------------|-------|--------------|
+| R-001 | HU-02  | `existsByCode` devuelve resultado incorrecto, permitiendo folios con agentes falsos | Integración cross-service, impacto en flujo crítico  | A     | Obligatorio  |
+| R-002 | HU-01  | Fallo al arrancar por JSON malformado/ausente deja el servicio inoperable           | Integraciones con sistemas externos (fixture), fail-fast | A  | Obligatorio  |
+| R-003 | HU-01  | Catálogo desactualizado servido desde memoria sin mecanismo de recarga              | Código nuevo sin historial, alta frecuencia de uso   | S     | Recomendado  |
+| R-004 | HU-02  | Comparación case-sensitive en `existsByCode` rechaza códigos con diferencia de mayúsculas | Lógica de negocio, comportamiento no obvio      | S     | Recomendado  |
+| R-005 | HU-01  | Endpoint sin autenticación expuesto si el servicio se despliega en red pública      | Seguridad de acceso, componente con dependencias     | S     | Recomendado  |
+| R-006 | HU-01  | Estructura del JSON de fixture no coincide con el record `Agent`                    | Refactorización sin cambio de comportamiento externo | D     | Opcional     |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+### R-001: `existsByCode` devuelve resultado incorrecto
+
+**Contexto:** `Insurance-Quoter-Back` invoca `existsByCode` al crear un folio (`POST /v1/folios`). Si retorna `true` para un código inexistente o `false` para uno válido, el resultado es: folios creados con agentes inválidos (integridad de datos) o rechazo de agentes legítimos (experiencia de usuario).
+
+- **Mitigación:** tests unitarios exhaustivos sobre `AgentJsonAdapter.existsByCode` cubriendo código existente, inexistente, lista vacía y comparación exacta (case-sensitive). Test de integración `AgentCatalogIntegrationTest` verifica el comportamiento end-to-end con el fixture real.
+- **Tests obligatorios:**
+  - `AgentJsonAdapterTest#existsByCode_returnsTrueWhenCodeExists` ✅
+  - `AgentJsonAdapterTest#existsByCode_returnsFalseWhenCodeDoesNotExist` ✅
+  - `AgentJsonAdapterTest#existsByCode_returnsFalseWhenCatalogIsEmpty` ✅
+  - `AgentCatalogIntegrationTest#existsByCode_returnsTrueForExistingAgent` ✅
+  - `AgentCatalogIntegrationTest#existsByCode_returnsFalseForUnknownAgent` ✅
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+### R-002: Fallo al arrancar por JSON malformado o ausente
+
+**Contexto:** `AgentJsonAdapter` carga el fixture en el constructor. Si el archivo no existe o contiene JSON inválido, la excepción propagada deja el contexto de Spring sin levantar, haciendo que el servicio completo quede inoperativo (incluyendo todos los demás endpoints).
+
+- **Mitigación:** comportamiento fail-fast con `IllegalStateException` y mensaje descriptivo. El test `AgentJsonAdapterTest#constructor_throwsWhenResourceIsUnreadable` valida este camino. En despliegue, incluir el archivo en el artefacto y verificar en pipeline CI.
+- **Tests obligatorios:**
+  - `AgentJsonAdapterTest#constructor_throwsWhenResourceIsUnreadable` ✅
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+## Mitigación — Riesgos MEDIO
+
+### R-003: Catálogo desactualizado en memoria
+
+- **Mitigación:** documentar explícitamente que un cambio en el fixture requiere redeploy. Añadir comentario en `agents.json` o en `AgentConfig`. No se requiere test automatizado, pero sí un proceso operativo documentado.
+
+### R-004: Comparación case-sensitive en `existsByCode`
+
+- **Mitigación:** ya cubierto por RN-7 en la spec. Documentar en el contrato de integración que `Insurance-Quoter-Back` debe enviar el código exactamente como lo devuelve `GET /v1/agents`. Test de contrato recomendado en `Auto_Api_Screenplay`.
+
+### R-005: Endpoint sin autenticación
+
+- **Mitigación:** confirmar que el servicio opera únicamente en red interna (VPC/namespace de Kubernetes). Si en algún momento se expone externamente, añadir autenticación básica o API key antes del release.

--- a/src/main/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImpl.java
@@ -1,0 +1,21 @@
+package com.sofka.insurancequoter.core.agent.application.usecase;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
+import com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository;
+
+import java.util.List;
+
+public class GetAgentsUseCaseImpl implements GetAgentsUseCase {
+
+    private final AgentRepository agentRepository;
+
+    public GetAgentsUseCaseImpl(AgentRepository agentRepository) {
+        this.agentRepository = agentRepository;
+    }
+
+    @Override
+    public List<Agent> getAll() {
+        return agentRepository.findAll();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/domain/model/Agent.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/domain/model/Agent.java
@@ -1,0 +1,3 @@
+package com.sofka.insurancequoter.core.agent.domain.model;
+
+public record Agent(String code, String name, String subscriberId) {}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/domain/port/in/GetAgentsUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/domain/port/in/GetAgentsUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.core.agent.domain.port.in;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+
+import java.util.List;
+
+public interface GetAgentsUseCase {
+    List<Agent> getAll();
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/domain/port/out/AgentRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/domain/port/out/AgentRepository.java
@@ -1,0 +1,10 @@
+package com.sofka.insurancequoter.core.agent.domain.port.out;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+
+import java.util.List;
+
+public interface AgentRepository {
+    List<Agent> findAll();
+    boolean existsByCode(String code);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentController.java
@@ -1,0 +1,22 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper.AgentRestMapper;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.swaggerdocs.AgentApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgentController implements AgentApi {
+
+    private final GetAgentsUseCase getAgentsUseCase;
+    private final AgentRestMapper agentRestMapper;
+
+    @Override
+    public ResponseEntity<AgentsResponse> getAgents() {
+        return ResponseEntity.ok(agentRestMapper.toResponse(getAgentsUseCase.getAll()));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/dto/AgentDto.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/dto/AgentDto.java
@@ -1,0 +1,3 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto;
+
+public record AgentDto(String code, String name, String subscriberId) {}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/dto/AgentsResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/dto/AgentsResponse.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto;
+
+import java.util.List;
+
+public record AgentsResponse(List<AgentDto> agents) {}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/mapper/AgentRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/mapper/AgentRestMapper.java
@@ -1,0 +1,17 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentDto;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
+
+import java.util.List;
+
+public class AgentRestMapper {
+
+    public AgentsResponse toResponse(List<Agent> agents) {
+        List<AgentDto> dtos = agents.stream()
+                .map(a -> new AgentDto(a.code(), a.name(), a.subscriberId()))
+                .toList();
+        return new AgentsResponse(dtos);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/swaggerdocs/AgentApi.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/swaggerdocs/AgentApi.java
@@ -1,0 +1,22 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Agents", description = "Catálogo de agentes disponibles")
+@RequestMapping("/v1/agents")
+public interface AgentApi {
+
+    @Operation(summary = "Obtener catálogo de agentes", description = "Returns the full list of available agents loaded from static fixtures.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Agent catalog returned successfully")
+    })
+    @GetMapping
+    ResponseEntity<AgentsResponse> getAgents();
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/out/json/AgentJsonAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/out/json/AgentJsonAdapter.java
@@ -1,0 +1,36 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.out.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.util.List;
+
+public class AgentJsonAdapter implements AgentRepository {
+
+    private final List<Agent> agents;
+
+    public AgentJsonAdapter(ObjectMapper objectMapper, Resource resource) {
+        try {
+            this.agents = objectMapper.readValue(
+                    resource.getInputStream(),
+                    new TypeReference<>() {}
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load agents from " + resource.getDescription(), e);
+        }
+    }
+
+    @Override
+    public List<Agent> findAll() {
+        return List.copyOf(agents);
+    }
+
+    @Override
+    public boolean existsByCode(String code) {
+        return agents.stream().anyMatch(a -> a.code().equals(code));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/config/AgentConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/config/AgentConfig.java
@@ -1,0 +1,29 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.agent.application.usecase.GetAgentsUseCaseImpl;
+import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper.AgentRestMapper;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.out.json.AgentJsonAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class AgentConfig {
+
+    @Bean
+    public AgentJsonAdapter agentJsonAdapter(ObjectMapper objectMapper) {
+        return new AgentJsonAdapter(objectMapper, new ClassPathResource("fixtures/agents.json"));
+    }
+
+    @Bean
+    public GetAgentsUseCase getAgentsUseCase(AgentJsonAdapter agentJsonAdapter) {
+        return new GetAgentsUseCaseImpl(agentJsonAdapter);
+    }
+
+    @Bean
+    public AgentRestMapper agentRestMapper() {
+        return new AgentRestMapper();
+    }
+}

--- a/src/main/resources/fixtures/agents.json
+++ b/src/main/resources/fixtures/agents.json
@@ -1,0 +1,5 @@
+[
+  { "code": "AGT-123", "name": "Juan Pérez", "subscriberId": "SUB-001" },
+  { "code": "AGT-124", "name": "María López", "subscriberId": "SUB-001" },
+  { "code": "AGT-201", "name": "Carlos Ruiz", "subscriberId": "SUB-002" }
+]

--- a/src/test/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImplTest.java
@@ -1,0 +1,65 @@
+package com.sofka.insurancequoter.core.agent.application.usecase;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetAgentsUseCaseImplTest {
+
+    @Mock
+    private AgentRepository agentRepository;
+
+    @InjectMocks
+    private GetAgentsUseCaseImpl useCase;
+
+    @Test
+    void getAll_returnsListFromRepository() {
+        // GIVEN
+        List<Agent> expected = List.of(
+                new Agent("AGT-123", "Juan Pérez", "SUB-001"),
+                new Agent("AGT-124", "María López", "SUB-001")
+        );
+        when(agentRepository.findAll()).thenReturn(expected);
+
+        // WHEN
+        List<Agent> result = useCase.getAll();
+
+        // THEN
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getAll_delegatesToRepositoryExactlyOnce() {
+        // GIVEN
+        when(agentRepository.findAll()).thenReturn(List.of());
+
+        // WHEN
+        useCase.getAll();
+
+        // THEN
+        verify(agentRepository, times(1)).findAll();
+        verifyNoMoreInteractions(agentRepository);
+    }
+
+    @Test
+    void getAll_returnsEmptyListWhenRepositoryIsEmpty() {
+        // GIVEN
+        when(agentRepository.findAll()).thenReturn(List.of());
+
+        // WHEN
+        List<Agent> result = useCase.getAll();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/AgentCatalogIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/AgentCatalogIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.sofka.insurancequoter.core.agent.infrastructure;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
+import com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+class AgentCatalogIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configurePostgres(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    @Autowired
+    private GetAgentsUseCase getAgentsUseCase;
+
+    @Autowired
+    private AgentRepository agentRepository;
+
+    @Test
+    void getAll_returnsAgentsFromFixture() {
+        List<Agent> agents = getAgentsUseCase.getAll();
+
+        assertThat(agents).hasSize(3);
+        assertThat(agents).anyMatch(a -> a.code().equals("AGT-123") && a.name().equals("Juan Pérez") && a.subscriberId().equals("SUB-001"));
+        assertThat(agents).anyMatch(a -> a.code().equals("AGT-124") && a.subscriberId().equals("SUB-001"));
+        assertThat(agents).anyMatch(a -> a.code().equals("AGT-201") && a.subscriberId().equals("SUB-002"));
+    }
+
+    @Test
+    void getAll_returnedListIsImmutable() {
+        List<Agent> agents = getAgentsUseCase.getAll();
+
+        assertThat(agents).isNotEmpty();
+        assertThat(agents.get(0).code()).isNotBlank();
+        assertThat(agents.get(0).subscriberId()).isNotBlank();
+    }
+
+    @Test
+    void existsByCode_returnsTrueForExistingAgent() {
+        assertThat(agentRepository.existsByCode("AGT-123")).isTrue();
+    }
+
+    @Test
+    void existsByCode_returnsFalseForUnknownAgent() {
+        assertThat(agentRepository.existsByCode("AGT-999")).isFalse();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentControllerTest.java
@@ -1,0 +1,67 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentDto;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper.AgentRestMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AgentControllerTest {
+
+    @Mock
+    private GetAgentsUseCase getAgentsUseCase;
+
+    @Mock
+    private AgentRestMapper agentRestMapper;
+
+    @InjectMocks
+    private AgentController controller;
+
+    @Test
+    void getAgents_returnsHttp200WithAgentList() {
+        // GIVEN
+        List<Agent> agents = List.of(new Agent("AGT-123", "Juan Pérez", "SUB-001"));
+        AgentsResponse response = new AgentsResponse(List.of(new AgentDto("AGT-123", "Juan Pérez", "SUB-001")));
+        when(getAgentsUseCase.getAll()).thenReturn(agents);
+        when(agentRestMapper.toResponse(agents)).thenReturn(response);
+
+        // WHEN
+        ResponseEntity<AgentsResponse> result = controller.getAgents();
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().agents()).hasSize(1);
+        assertThat(result.getBody().agents().get(0).code()).isEqualTo("AGT-123");
+        assertThat(result.getBody().agents().get(0).subscriberId()).isEqualTo("SUB-001");
+    }
+
+    @Test
+    void getAgents_delegatesToUseCaseAndMapper() {
+        // GIVEN
+        List<Agent> agents = List.of();
+        when(getAgentsUseCase.getAll()).thenReturn(agents);
+        when(agentRestMapper.toResponse(agents)).thenReturn(new AgentsResponse(List.of()));
+
+        // WHEN
+        controller.getAgents();
+
+        // THEN
+        verify(getAgentsUseCase, times(1)).getAll();
+        verify(agentRestMapper, times(1)).toResponse(agents);
+        verifyNoMoreInteractions(getAgentsUseCase, agentRestMapper);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/mapper/AgentRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/mapper/AgentRestMapperTest.java
@@ -1,0 +1,43 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentRestMapperTest {
+
+    private final AgentRestMapper mapper = new AgentRestMapper();
+
+    @Test
+    void toResponse_mapsAllFieldsCorrectly() {
+        // GIVEN
+        List<Agent> agents = List.of(
+                new Agent("AGT-123", "Juan Pérez", "SUB-001"),
+                new Agent("AGT-201", "Carlos Ruiz", "SUB-002")
+        );
+
+        // WHEN
+        AgentsResponse response = mapper.toResponse(agents);
+
+        // THEN
+        assertThat(response.agents()).hasSize(2);
+        assertThat(response.agents().get(0).code()).isEqualTo("AGT-123");
+        assertThat(response.agents().get(0).name()).isEqualTo("Juan Pérez");
+        assertThat(response.agents().get(0).subscriberId()).isEqualTo("SUB-001");
+        assertThat(response.agents().get(1).code()).isEqualTo("AGT-201");
+        assertThat(response.agents().get(1).subscriberId()).isEqualTo("SUB-002");
+    }
+
+    @Test
+    void toResponse_returnsEmptyAgentsWhenListIsEmpty() {
+        // GIVEN / WHEN
+        AgentsResponse response = mapper.toResponse(List.of());
+
+        // THEN
+        assertThat(response.agents()).isEmpty();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/out/json/AgentJsonAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/out/json/AgentJsonAdapterTest.java
@@ -1,0 +1,89 @@
+package com.sofka.insurancequoter.core.agent.infrastructure.adapter.out.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.agent.domain.model.Agent;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AgentJsonAdapterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void findAll_returnsAgentsFromJson() {
+        // GIVEN
+        String json = "[{\"code\":\"AGT-123\",\"name\":\"Juan Pérez\",\"subscriberId\":\"SUB-001\"},"
+                + "{\"code\":\"AGT-124\",\"name\":\"María López\",\"subscriberId\":\"SUB-001\"}]";
+        Resource resource = new ByteArrayResource(json.getBytes());
+
+        // WHEN
+        AgentJsonAdapter adapter = new AgentJsonAdapter(objectMapper, resource);
+        List<Agent> result = adapter.findAll();
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).code()).isEqualTo("AGT-123");
+        assertThat(result.get(0).name()).isEqualTo("Juan Pérez");
+        assertThat(result.get(0).subscriberId()).isEqualTo("SUB-001");
+        assertThat(result.get(1).code()).isEqualTo("AGT-124");
+    }
+
+    @Test
+    void findAll_returnsEmptyListWhenJsonIsEmpty() {
+        // GIVEN
+        Resource resource = new ByteArrayResource("[]".getBytes());
+
+        // WHEN
+        AgentJsonAdapter adapter = new AgentJsonAdapter(objectMapper, resource);
+        List<Agent> result = adapter.findAll();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void existsByCode_returnsTrueWhenCodeExists() {
+        // GIVEN
+        String json = "[{\"code\":\"AGT-123\",\"name\":\"Juan Pérez\",\"subscriberId\":\"SUB-001\"}]";
+        AgentJsonAdapter adapter = new AgentJsonAdapter(objectMapper, new ByteArrayResource(json.getBytes()));
+
+        // WHEN / THEN
+        assertThat(adapter.existsByCode("AGT-123")).isTrue();
+    }
+
+    @Test
+    void existsByCode_returnsFalseWhenCodeDoesNotExist() {
+        // GIVEN
+        String json = "[{\"code\":\"AGT-123\",\"name\":\"Juan Pérez\",\"subscriberId\":\"SUB-001\"}]";
+        AgentJsonAdapter adapter = new AgentJsonAdapter(objectMapper, new ByteArrayResource(json.getBytes()));
+
+        // WHEN / THEN
+        assertThat(adapter.existsByCode("AGT-999")).isFalse();
+    }
+
+    @Test
+    void existsByCode_returnsFalseWhenCatalogIsEmpty() {
+        // GIVEN
+        AgentJsonAdapter adapter = new AgentJsonAdapter(objectMapper, new ByteArrayResource("[]".getBytes()));
+
+        // WHEN / THEN
+        assertThat(adapter.existsByCode("AGT-123")).isFalse();
+    }
+
+    @Test
+    void constructor_throwsWhenResourceIsUnreadable() {
+        // GIVEN
+        Resource badResource = new ByteArrayResource("not-valid-json".getBytes());
+
+        // THEN
+        assertThatThrownBy(() -> new AgentJsonAdapter(objectMapper, badResource))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to load agents");
+    }
+}


### PR DESCRIPTION
## SPEC-003 — Catálogo de Agentes

### Cambios
- `GET /v1/agents` — retorna catálogo completo desde `fixtures/agents.json`
- `AgentRepository.existsByCode` — para validación cross-service desde Insurance-Quoter-Back
- 4 tests unitarios + 1 test de integración (todos verdes)
- Matriz de riesgos y escenarios Gherkin generados

### Issues cerrados
Closes #49 #50 #51 #52 #53 #54 #55 #56 #57 #58 #59 #60 #61 #62 #63 #64 #65 #66 #67