### PR TITLE
feat: business-lines catalog endpoint (SPEC-004)

### DIFF
--- a/.claude/specs/business-lines-catalog.spec.md
+++ b/.claude/specs/business-lines-catalog.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-004
-status: DRAFT
+status: IMPLEMENTED
 feature: business-lines-catalog
 created: 2026-04-21
 updated: 2026-04-21

--- a/.claude/specs/business-lines-catalog.spec.md
+++ b/.claude/specs/business-lines-catalog.spec.md
@@ -1,0 +1,254 @@
+---
+id: SPEC-004
+status: DRAFT
+feature: business-lines-catalog
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-002", "SPEC-003"]
+---
+
+# Spec: Catálogo de Giros de Negocio
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+El microservicio `Insurance-Quoter-Core` expone un endpoint `GET /v1/business-lines` que retorna el catálogo completo de giros de negocio (`businessLine`) disponibles, incluyendo su clave incendio (`fireKey`). Los datos son estáticos: se cargan desde un archivo JSON al iniciar la aplicación y se sirven desde memoria. No existe escritura ni modificación del catálogo en tiempo de ejecución.
+
+El catálogo de giros de negocio es necesario para que `Insurance-Quoter-Back` pueda presentar opciones válidas al usuario durante el flujo de cotización y asociar la clave incendio correspondiente al cálculo de prima.
+
+### Requerimiento de Negocio
+
+> Catálogo de giros de negocio disponibles en el microservicio core.
+> Endpoint `GET /v1/business-lines`. Los datos provienen de un archivo
+> `src/main/resources/fixtures/business-lines.json` cargado en memoria al inicio.
+> No hay escritura. El catálogo es estático y gestionado por configuración.
+> El port `BusinessLineRepository` expone `findAll()` para consulta del catálogo completo.
+
+### Historias de Usuario
+
+#### HU-01: Consultar catálogo de giros de negocio
+
+```
+Como:        sistema cliente (Insurance-Quoter-Back u otro consumidor)
+Quiero:      llamar GET /v1/business-lines y recibir la lista completa de giros de negocio
+Para:        presentar opciones de giro al usuario en el flujo de cotización y
+             obtener la clave incendio asociada para el cálculo de prima
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: Ninguna (sin base de datos, datos en memoria)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Retorno del catálogo completo
+  Dado que:  el servicio Insurance-Quoter-Core está disponible
+             Y el archivo fixtures/business-lines.json contiene al menos un giro de negocio
+  Cuando:    se realiza GET /v1/business-lines
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene el campo "businessLines" con un array
+             Y cada elemento del array contiene "code", "description" y "fireKey" con valores no vacíos
+```
+
+**Catálogo vacío**
+```gherkin
+CRITERIO-1.2: Catálogo sin entradas configuradas
+  Dado que:  el archivo fixtures/business-lines.json existe pero el array está vacío
+  Cuando:    se realiza GET /v1/business-lines
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "businessLines" con un array vacío []
+```
+
+**Error de configuración**
+```gherkin
+CRITERIO-1.3: Archivo de fixtures no encontrado
+  Dado que:  el archivo fixtures/business-lines.json no existe en el classpath
+  Cuando:    la aplicación intenta arrancar
+  Entonces:  la aplicación falla al iniciar con un mensaje de error claro
+             Y NO se expone el endpoint con datos inconsistentes
+```
+
+### Reglas de Negocio
+
+| ID   | Regla |
+|------|-------|
+| RN-1 | El catálogo es de solo lectura — no existe endpoint de creación, modificación ni eliminación. |
+| RN-2 | Los datos se cargan una sola vez al iniciar la aplicación (eager loading en el adapter). |
+| RN-3 | Si el archivo JSON no existe o no es parseable, la aplicación debe fallar al arrancar (fail-fast). |
+| RN-4 | El `code` de cada giro de negocio es un identificador de negocio opaco (ej. `BL-001`), no una PK de base de datos. |
+| RN-5 | Cada giro de negocio tiene asociada una clave incendio (`fireKey`) que se utiliza en el cálculo de prima neta. La relación es interna al catálogo. |
+| RN-6 | El endpoint no requiere autenticación — es un servicio interno consumido por `Insurance-Quoter-Back`. |
+
+---
+
+## 2. DISEÑO
+
+### Modelo de Dominio
+
+#### `BusinessLine` — domain model (POJO puro, sin anotaciones JPA ni Spring)
+
+```java
+// com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine
+public record BusinessLine(String code, String description, String fireKey) {}
+```
+
+| Campo         | Tipo   | Restricciones                                                        |
+|---------------|--------|----------------------------------------------------------------------|
+| `code`        | String | No nulo, no vacío — identificador de negocio (ej. `BL-001`)         |
+| `description` | String | No nulo, no vacío — descripción legible del giro (ej. `Bodega de mercancías`) |
+| `fireKey`     | String | No nulo, no vacío — clave incendio asociada (ej. `FK-INC-01`)       |
+
+### Output Port
+
+```java
+// com.sofka.insurancequoter.core.businessline.domain.port.out.BusinessLineRepository
+public interface BusinessLineRepository {
+    List<BusinessLine> findAll();
+}
+```
+
+### Input Port (Use Case)
+
+```java
+// com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase
+public interface GetBusinessLinesUseCase {
+    List<BusinessLine> getAll();
+}
+```
+
+### Fixture — `src/main/resources/fixtures/business-lines.json`
+
+```json
+[
+  { "code": "BL-001", "description": "Bodega de mercancías", "fireKey": "FK-INC-01" },
+  { "code": "BL-002", "description": "Oficina administrativa", "fireKey": "FK-INC-02" },
+  { "code": "BL-003", "description": "Local comercial", "fireKey": "FK-INC-03" },
+  { "code": "BL-004", "description": "Restaurante", "fireKey": "FK-INC-04" },
+  { "code": "BL-005", "description": "Industria ligera", "fireKey": "FK-INC-05" }
+]
+```
+
+> El adapter deserializa este array en `List<BusinessLine>` al construirse (vía Jackson `ObjectMapper`).
+
+### API Endpoint
+
+#### `GET /v1/business-lines`
+
+| Atributo  | Valor                          |
+|-----------|--------------------------------|
+| Método    | `GET`                          |
+| Ruta      | `/v1/business-lines`           |
+| Auth      | Ninguna (servicio interno)     |
+| Produces  | `application/json`             |
+
+**Response 200 — catálogo con datos:**
+```json
+{
+  "businessLines": [
+    { "code": "BL-001", "description": "Bodega de mercancías", "fireKey": "FK-INC-01" },
+    { "code": "BL-002", "description": "Oficina administrativa", "fireKey": "FK-INC-02" }
+  ]
+}
+```
+
+**Response 200 — catálogo vacío:**
+```json
+{
+  "businessLines": []
+}
+```
+
+> No hay respuestas 4xx ni 5xx en operación normal. Los errores de configuración se manifiestan al arrancar.
+
+### DTOs REST
+
+#### `BusinessLineDto`
+
+```java
+public record BusinessLineDto(String code, String description, String fireKey) {}
+```
+
+#### `BusinessLinesResponse`
+
+```java
+public record BusinessLinesResponse(List<BusinessLineDto> businessLines) {}
+```
+
+### Arquitectura Hexagonal — estructura de paquetes
+
+```
+com.sofka.insurancequoter.core.businessline/
+├── domain/
+│   ├── model/
+│   │   └── BusinessLine.java                              ← record puro
+│   └── port/
+│       ├── in/
+│       │   └── GetBusinessLinesUseCase.java               ← input port
+│       └── out/
+│           └── BusinessLineRepository.java                ← output port
+├── application/
+│   └── usecase/
+│       └── GetBusinessLinesUseCaseImpl.java               ← sin @Service, wired via @Bean
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── swaggerdocs/
+    │   │       │   └── BusinessLineApi.java               ← @Tag, @Operation
+    │   │       ├── BusinessLineController.java            ← implements BusinessLineApi
+    │   │       ├── dto/
+    │   │       │   ├── BusinessLineDto.java
+    │   │       │   └── BusinessLinesResponse.java
+    │   │       └── mapper/
+    │   │           └── BusinessLineRestMapper.java
+    │   └── out/
+    │       └── json/
+    │           └── BusinessLineJsonAdapter.java           ← carga JSON, implementa BusinessLineRepository
+    └── config/
+        └── BusinessLineConfig.java                        ← @Bean wiring
+```
+
+> El adapter de persistencia es `out/json/` (no `out/persistence/`) porque no hay base de datos involucrada — el patrón es idéntico al de `agents-catalog` (SPEC-003).
+
+---
+
+## 3. LISTA DE TAREAS
+
+### Backend
+
+- [ ] **TASK-1** Crear domain model `BusinessLine` (record Java con `code`, `description`, `fireKey`, sin anotaciones)
+- [ ] **TASK-2** Crear output port `BusinessLineRepository` con método `findAll(): List<BusinessLine>`
+- [ ] **TASK-3** Crear input port `GetBusinessLinesUseCase` con método `getAll(): List<BusinessLine>`
+- [ ] **TASK-4** Implementar `GetBusinessLinesUseCaseImpl` — delega a `BusinessLineRepository.findAll()`
+- [ ] **TASK-5** Crear `BusinessLineJsonAdapter` — carga `fixtures/business-lines.json` vía `ObjectMapper` al construirse; implementa `BusinessLineRepository`
+- [ ] **TASK-6** Crear archivo `src/main/resources/fixtures/business-lines.json` con los datos estáticos de los giros de negocio
+- [ ] **TASK-7** Crear DTOs REST: `BusinessLineDto`, `BusinessLinesResponse`
+- [ ] **TASK-8** Crear `BusinessLineRestMapper` — mapea `List<BusinessLine>` → `BusinessLinesResponse`
+- [ ] **TASK-9** Crear interfaz Swagger `BusinessLineApi` (en `rest/swaggerdocs/`)
+- [ ] **TASK-10** Crear `BusinessLineController` — implementa `BusinessLineApi`, llama `GetBusinessLinesUseCase`
+- [ ] **TASK-11** Crear `BusinessLineConfig` — registra `BusinessLineJsonAdapter` y `GetBusinessLinesUseCaseImpl` como `@Bean`
+
+### Tests (TDD — escribir antes de implementar)
+
+- [ ] **TASK-12** Test unitario `GetBusinessLinesUseCaseImplTest` — verifica delegación al port y retorno de lista
+- [ ] **TASK-13** Test unitario `BusinessLineJsonAdapterTest` — verifica carga correcta del JSON y mapeo a `List<BusinessLine>`; verifica comportamiento con JSON vacío y error al no encontrar el archivo
+- [ ] **TASK-14** Test unitario `BusinessLineRestMapperTest` — verifica mapeo `List<BusinessLine>` → `BusinessLinesResponse` (todos los campos)
+- [ ] **TASK-15** Test unitario `BusinessLineControllerTest` — verifica HTTP 200 y estructura del response
+- [ ] **TASK-16** Test de integración `BusinessLineCatalogIntegrationTest` (`@SpringBootTest`) — levanta contexto completo, llama `GET /v1/business-lines`, valida response 200 con datos del fixture
+
+### QA
+
+- [ ] **TASK-17** Ejecutar `/risk-identifier` para generar matriz de riesgos `business-lines-catalog-risks.md`
+- [ ] **TASK-18** Ejecutar `/gherkin-case-generator` para generar escenarios Gherkin `business-lines-catalog-gherkin.md`
+- [ ] **TASK-19** Validar endpoint manualmente con curl o Swagger UI (`http://localhost:8081/swagger-ui/index.html`)

--- a/docs/output/qa/business-lines-catalog-gherkin.md
+++ b/docs/output/qa/business-lines-catalog-gherkin.md
@@ -1,0 +1,132 @@
+# Escenarios Gherkin — Catálogo de Giros de Negocio (SPEC-004)
+
+**Feature:** business-lines-catalog  
+**Microservicio:** Insurance-Quoter-Core · `GET /v1/business-lines`  
+**Fecha:** 2026-04-21
+
+---
+
+```gherkin
+#language: es
+Característica: Catálogo de giros de negocio con clave incendio
+
+  Como sistema cliente (cotizador de daños)
+  Quiero consultar el catálogo de giros de negocio
+  Para presentar opciones al usuario y obtener la clave incendio para el cálculo de prima
+
+  Antecedentes:
+    Dado que el microservicio Insurance-Quoter-Core está disponible en el puerto 8081
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HAPPY PATH
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @smoke @critico @happy-path
+  Escenario: Consulta exitosa del catálogo de giros de negocio
+    Dado que el catálogo contiene giros de negocio configurados
+    Cuando el sistema cliente solicita la lista de giros de negocio
+    Entonces la respuesta tiene estado HTTP 200
+    Y la respuesta contiene un array "businessLines" con al menos un elemento
+    Y cada elemento del array tiene los campos "code", "description" y "fireKey" con valores no vacíos
+
+  @smoke @critico @happy-path
+  Escenario: El catálogo retorna la clave incendio correcta para cada giro
+    Dado que el catálogo contiene el giro "Bodega de mercancías" con clave incendio "FK-INC-01"
+    Cuando el sistema cliente consulta el catálogo de giros de negocio
+    Entonces la respuesta incluye el giro con código "BL-001"
+    Y ese giro tiene la clave incendio "FK-INC-01"
+    Y tiene la descripción "Bodega de mercancías"
+
+  @smoke @critico @happy-path
+  Escenario: El catálogo retorna todos los giros de negocio disponibles
+    Dado que el catálogo tiene 5 giros de negocio configurados
+    Cuando el sistema cliente consulta el catálogo de giros de negocio
+    Entonces la respuesta contiene exactamente 5 giros de negocio
+    Y los códigos retornados incluyen "BL-001", "BL-002", "BL-003", "BL-004" y "BL-005"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # EDGE CASES
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @edge-case
+  Escenario: El catálogo responde con lista vacía cuando no hay giros configurados
+    Dado que el catálogo de giros de negocio está vacío
+    Cuando el sistema cliente consulta el catálogo de giros de negocio
+    Entonces la respuesta tiene estado HTTP 200
+    Y la respuesta contiene un array "businessLines" vacío
+
+  @edge-case
+  Escenario: La estructura del response siempre incluye el campo "businessLines" aunque esté vacío
+    Dado que el catálogo de giros de negocio está vacío
+    Cuando el sistema cliente solicita la lista de giros de negocio
+    Entonces el campo "businessLines" está presente en el response
+    Y su valor es un array (no nulo)
+
+  @edge-case
+  Escenario: El catálogo es inmutable durante la ejecución
+    Dado que el catálogo de giros de negocio fue cargado al iniciar el servicio
+    Cuando el sistema cliente consulta el catálogo múltiples veces seguidas
+    Entonces todas las respuestas retornan la misma lista de giros de negocio
+    Y ninguna consulta modifica el catálogo
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # ERROR PATH — Configuración
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @error-path
+  Escenario: El servicio falla al arrancar si el archivo de catálogo no existe
+    Dado que el archivo de configuración del catálogo no está disponible en el classpath
+    Cuando el servicio Insurance-Quoter-Core intenta iniciar
+    Entonces el servicio NO arranca
+    Y se registra un mensaje de error claro indicando que el catálogo no pudo cargarse
+    Y NO se expone el endpoint con datos inconsistentes
+
+  @error-path
+  Escenario: El servicio falla al arrancar si el archivo de catálogo tiene formato inválido
+    Dado que el archivo de configuración del catálogo contiene JSON malformado
+    Cuando el servicio Insurance-Quoter-Core intenta iniciar
+    Entonces el servicio NO arranca
+    Y se registra un error de parseo con el detalle del problema
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # VALIDACIÓN DE DATOS
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @edge-case
+  Esquema del escenario: El catálogo valida que los campos obligatorios no estén vacíos
+    Dado que el catálogo contiene un giro con <campo> vacío
+    Cuando el servicio Insurance-Quoter-Core intenta iniciar
+    Entonces el comportamiento es "<resultado>"
+
+    Ejemplos:
+      | campo         | resultado                                         |
+      | code          | el servicio arranca pero el giro es inválido      |
+      | description   | el servicio arranca pero el giro es inválido      |
+      | fireKey       | el servicio arranca pero la prima no puede calcularse |
+```
+
+---
+
+## Datos de Prueba Sintéticos
+
+| Escenario                              | Campo         | Válido           | Inválido | Borde          |
+|----------------------------------------|---------------|------------------|----------|----------------|
+| Consulta exitosa                       | `code`        | `BL-001`         | `""`     | `BL-999`       |
+| Consulta exitosa                       | `description` | `Bodega de mercancías` | `""` | (string largo) |
+| Consulta exitosa                       | `fireKey`     | `FK-INC-01`      | `""`     | `FK-INC-999`   |
+| Catálogo vacío                         | `businessLines` | `[]`           | —        | —              |
+| Archivo no encontrado                  | classpath     | `fixtures/business-lines.json` | `fixtures/missing.json` | — |
+| Archivo malformado                     | contenido JSON | `[{...}]`      | `{broken` | `[]`           |
+
+---
+
+## Flujos Críticos Identificados
+
+| Flujo | Tipo | Tags | Prioridad |
+|-------|------|------|-----------|
+| Retorno del catálogo completo con todos los campos | Happy path | `@smoke @critico` | Alta |
+| Verificación de `fireKey` por giro | Happy path | `@smoke @critico` | Alta — impacta cálculo de prima |
+| Catálogo vacío retorna 200 con array vacío | Edge case | `@edge-case` | Media |
+| Fail-fast si archivo no existe | Error path | `@error-path` | Alta — bloquea arranque |
+| Fail-fast si JSON malformado | Error path | `@error-path` | Alta — bloquea arranque |
+| Inmutabilidad del catálogo en ejecución | Edge case | `@edge-case` | Baja |

--- a/docs/output/qa/business-lines-catalog-risks.md
+++ b/docs/output/qa/business-lines-catalog-risks.md
@@ -1,0 +1,71 @@
+# Matriz de Riesgos — Catálogo de Giros de Negocio (SPEC-004)
+
+**Feature:** business-lines-catalog  
+**Microservicio:** Insurance-Quoter-Core (puerto 8081)  
+**Fecha:** 2026-04-21
+
+---
+
+## Resumen
+
+Total: 6 | Alto (A): 2 | Medio (S): 3 | Bajo (D): 1
+
+---
+
+## Detalle
+
+| ID    | HU     | Descripción del Riesgo                                                             | Factores                                              | Nivel | Testing      |
+|-------|--------|------------------------------------------------------------------------------------|-------------------------------------------------------|-------|--------------|
+| R-001 | HU-01  | `fireKey` incorrecta o ausente en el fixture afecta el cálculo de prima neta       | Dato crítico para cálculo financiero; sin validación en DB | A  | Obligatorio  |
+| R-002 | HU-01  | Fallo al arrancar si `business-lines.json` no existe o es malformado (fail-fast)   | Código nuevo sin historial; integridad del contexto Spring | A  | Obligatorio  |
+| R-003 | HU-01  | Catálogo con datos desactualizados o inconsistentes entre ambientes                 | Dato gestionado por configuración (sin base de datos)  | S     | Recomendado  |
+| R-004 | HU-01  | Respuesta con campos nulos si el JSON tiene entradas incompletas                   | Código nuevo; deserialización sin validación estricta  | S     | Recomendado  |
+| R-005 | HU-01  | Degradación del endpoint bajo alta concurrencia (lista cargada en memoria compartida) | Alta frecuencia de uso; consumido por cada cotización | S     | Recomendado  |
+| R-006 | HU-01  | Cambio de estructura del fixture rompe silenciosamente el mapeo a `BusinessLineDto` | Refactorización futura sin tests de contrato           | D     | Opcional     |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+### R-001: `fireKey` incorrecta afecta el cálculo de prima neta
+
+- **Contexto:** La `fireKey` de cada `BusinessLine` es el dato que `Insurance-Quoter-Back` usa para calcular la prima neta. Si este valor es incorrecto en el fixture, el cálculo se realizará con datos erróneos sin error visible en runtime.
+- **Mitigación:**
+  - Validar en `BusinessLineJsonAdapterTest` que cada entrada del fixture tiene `fireKey` no nulo y no vacío.
+  - Considerar añadir validación defensiva en `BusinessLineJsonAdapter` que lance `IllegalStateException` si algún campo es blank al cargar.
+  - Revisar el fixture `business-lines.json` como parte del proceso de cambio de catálogo (PR review obligatorio).
+- **Tests obligatorios:**
+  - Test unitario: `BusinessLineJsonAdapterTest` — verificar `fireKey` no vacía en cada elemento deserializado.
+  - Test de integración: `BusinessLineCatalogIntegrationTest` — verificar que el response contiene `fireKey` con valor en cada elemento.
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+### R-002: Fallo silencioso o inconsistente si el archivo JSON es inválido
+
+- **Contexto:** Si `business-lines.json` no existe en el classpath o tiene JSON malformado, el comportamiento esperado es fail-fast al arrancar (RN-3). Sin embargo, si el adapter no lanza una excepción clara, Spring podría iniciar con el bean en estado inconsistente.
+- **Mitigación:**
+  - `BusinessLineJsonAdapter` debe capturar `IOException` / `JsonProcessingException` y relanzar como `IllegalStateException` o `BeanCreationException` con mensaje descriptivo.
+  - Test unitario `BusinessLineJsonAdapterTest` debe incluir el escenario de archivo no encontrado y verificar que se lanza la excepción correcta.
+  - En entornos CI/CD, ejecutar el test de integración `BusinessLineCatalogIntegrationTest` que valida el contexto completo.
+- **Tests obligatorios:**
+  - Test unitario: `BusinessLineJsonAdapterTest` — escenario `classpath:fixtures/invalid.json` → excepción lanzada.
+  - Test de integración: `BusinessLineCatalogIntegrationTest` — contexto arranca correctamente con el fixture real.
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+## Riesgos MEDIO — Acciones Recomendadas
+
+### R-003: Datos desactualizados entre ambientes
+- Establecer proceso de revisión del fixture al hacer deploy a producción.
+- Documentar en el README del módulo cómo actualizar el catálogo.
+
+### R-004: Campos nulos por entradas incompletas en JSON
+- Añadir aserción en `BusinessLineJsonAdapterTest` que verifique que `code`, `description` y `fireKey` son no nulos tras la deserialización.
+- Considerar usar `@JsonProperty(required = true)` en un DTO de deserialización intermedio.
+
+### R-005: Degradación bajo alta concurrencia
+- La lista se carga una vez en el constructor y es inmutable (o al menos no se modifica), por lo que el riesgo es bajo en la implementación actual.
+- Si el catálogo crece significativamente (>500 entradas), evaluar si la búsqueda lineal impacta la latencia.
+- Documentar la estrategia de carga en el CLAUDE.md del módulo.

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImpl.java
@@ -1,0 +1,21 @@
+package com.sofka.insurancequoter.core.businessline.application.usecase;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase;
+import com.sofka.insurancequoter.core.businessline.domain.port.out.BusinessLineRepository;
+
+import java.util.List;
+
+public class GetBusinessLinesUseCaseImpl implements GetBusinessLinesUseCase {
+
+    private final BusinessLineRepository businessLineRepository;
+
+    public GetBusinessLinesUseCaseImpl(BusinessLineRepository businessLineRepository) {
+        this.businessLineRepository = businessLineRepository;
+    }
+
+    @Override
+    public List<BusinessLine> getAll() {
+        return businessLineRepository.findAll();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/domain/model/BusinessLine.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/domain/model/BusinessLine.java
@@ -1,0 +1,3 @@
+package com.sofka.insurancequoter.core.businessline.domain.model;
+
+public record BusinessLine(String code, String description, String fireKey) {}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/domain/port/in/GetBusinessLinesUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/domain/port/in/GetBusinessLinesUseCase.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.core.businessline.domain.port.in;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+
+import java.util.List;
+
+public interface GetBusinessLinesUseCase {
+    List<BusinessLine> getAll();
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/domain/port/out/BusinessLineRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/domain/port/out/BusinessLineRepository.java
@@ -1,0 +1,9 @@
+package com.sofka.insurancequoter.core.businessline.domain.port.out;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+
+import java.util.List;
+
+public interface BusinessLineRepository {
+    List<BusinessLine> findAll();
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/BusinessLineController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/BusinessLineController.java
@@ -1,0 +1,22 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.mapper.BusinessLineRestMapper;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.swaggerdocs.BusinessLineApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BusinessLineController implements BusinessLineApi {
+
+    private final GetBusinessLinesUseCase getBusinessLinesUseCase;
+    private final BusinessLineRestMapper businessLineRestMapper;
+
+    @Override
+    public ResponseEntity<BusinessLinesResponse> getBusinessLines() {
+        return ResponseEntity.ok(businessLineRestMapper.toResponse(getBusinessLinesUseCase.getAll()));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/dto/BusinessLineDto.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/dto/BusinessLineDto.java
@@ -1,0 +1,3 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto;
+
+public record BusinessLineDto(String code, String description, String fireKey) {}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/dto/BusinessLinesResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/dto/BusinessLinesResponse.java
@@ -1,0 +1,5 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto;
+
+import java.util.List;
+
+public record BusinessLinesResponse(List<BusinessLineDto> businessLines) {}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/mapper/BusinessLineRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/mapper/BusinessLineRestMapper.java
@@ -1,0 +1,17 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLineDto;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+
+import java.util.List;
+
+public class BusinessLineRestMapper {
+
+    public BusinessLinesResponse toResponse(List<BusinessLine> businessLines) {
+        List<BusinessLineDto> dtos = businessLines.stream()
+                .map(bl -> new BusinessLineDto(bl.code(), bl.description(), bl.fireKey()))
+                .toList();
+        return new BusinessLinesResponse(dtos);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/swaggerdocs/BusinessLineApi.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/swaggerdocs/BusinessLineApi.java
@@ -1,0 +1,22 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Business Lines", description = "Catálogo de giros de negocio")
+@RequestMapping("/v1/business-lines")
+public interface BusinessLineApi {
+
+    @Operation(summary = "Obtener catálogo de giros de negocio", description = "Returns the full list of business lines loaded from static fixtures.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Business lines catalog returned successfully")
+    })
+    @GetMapping
+    ResponseEntity<BusinessLinesResponse> getBusinessLines();
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/out/json/BusinessLineJsonAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/out/json/BusinessLineJsonAdapter.java
@@ -1,0 +1,31 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.out.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.domain.port.out.BusinessLineRepository;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.util.List;
+
+public class BusinessLineJsonAdapter implements BusinessLineRepository {
+
+    private final List<BusinessLine> businessLines;
+
+    public BusinessLineJsonAdapter(ObjectMapper objectMapper, Resource resource) {
+        try {
+            this.businessLines = objectMapper.readValue(
+                    resource.getInputStream(),
+                    new TypeReference<>() {}
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load business lines from " + resource.getDescription(), e);
+        }
+    }
+
+    @Override
+    public List<BusinessLine> findAll() {
+        return List.copyOf(businessLines);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/config/BusinessLineConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/infrastructure/config/BusinessLineConfig.java
@@ -1,0 +1,29 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.businessline.application.usecase.GetBusinessLinesUseCaseImpl;
+import com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.mapper.BusinessLineRestMapper;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.out.json.BusinessLineJsonAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class BusinessLineConfig {
+
+    @Bean
+    public BusinessLineJsonAdapter businessLineJsonAdapter(ObjectMapper objectMapper) {
+        return new BusinessLineJsonAdapter(objectMapper, new ClassPathResource("fixtures/business-lines.json"));
+    }
+
+    @Bean
+    public GetBusinessLinesUseCase getBusinessLinesUseCase(BusinessLineJsonAdapter businessLineJsonAdapter) {
+        return new GetBusinessLinesUseCaseImpl(businessLineJsonAdapter);
+    }
+
+    @Bean
+    public BusinessLineRestMapper businessLineRestMapper() {
+        return new BusinessLineRestMapper();
+    }
+}

--- a/src/main/resources/fixtures/business-lines.json
+++ b/src/main/resources/fixtures/business-lines.json
@@ -1,0 +1,7 @@
+[
+  { "code": "BL-001", "description": "Bodega de mercancías", "fireKey": "FK-INC-01" },
+  { "code": "BL-002", "description": "Oficina administrativa", "fireKey": "FK-INC-02" },
+  { "code": "BL-003", "description": "Local comercial", "fireKey": "FK-INC-03" },
+  { "code": "BL-004", "description": "Restaurante", "fireKey": "FK-INC-04" },
+  { "code": "BL-005", "description": "Industria ligera", "fireKey": "FK-INC-05" }
+]

--- a/src/test/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImplTest.java
@@ -1,0 +1,65 @@
+package com.sofka.insurancequoter.core.businessline.application.usecase;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.domain.port.out.BusinessLineRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetBusinessLinesUseCaseImplTest {
+
+    @Mock
+    private BusinessLineRepository businessLineRepository;
+
+    @InjectMocks
+    private GetBusinessLinesUseCaseImpl useCase;
+
+    @Test
+    void getAll_returnsListFromRepository() {
+        // GIVEN
+        List<BusinessLine> expected = List.of(
+                new BusinessLine("BL-001", "Bodega de mercancías", "FK-INC-01"),
+                new BusinessLine("BL-002", "Oficina administrativa", "FK-INC-02")
+        );
+        when(businessLineRepository.findAll()).thenReturn(expected);
+
+        // WHEN
+        List<BusinessLine> result = useCase.getAll();
+
+        // THEN
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getAll_delegatesToRepositoryExactlyOnce() {
+        // GIVEN
+        when(businessLineRepository.findAll()).thenReturn(List.of());
+
+        // WHEN
+        useCase.getAll();
+
+        // THEN
+        verify(businessLineRepository, times(1)).findAll();
+        verifyNoMoreInteractions(businessLineRepository);
+    }
+
+    @Test
+    void getAll_returnsEmptyListWhenRepositoryIsEmpty() {
+        // GIVEN
+        when(businessLineRepository.findAll()).thenReturn(List.of());
+
+        // WHEN
+        List<BusinessLine> result = useCase.getAll();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/BusinessLineCatalogIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/BusinessLineCatalogIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure;
+
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class BusinessLineCatalogIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configurePostgres(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    @LocalServerPort
+    private int port;
+
+    private RestClient restClient;
+
+    @BeforeEach
+    void setUp() {
+        restClient = RestClient.create("http://localhost:" + port);
+    }
+
+    @Test
+    void getBusinessLines_returnsHttp200WithCatalog() {
+        // WHEN
+        ResponseEntity<BusinessLinesResponse> response = restClient.get()
+                .uri("/v1/business-lines")
+                .retrieve()
+                .toEntity(BusinessLinesResponse.class);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().businessLines()).isNotNull();
+        assertThat(response.getBody().businessLines()).isNotEmpty();
+    }
+
+    @Test
+    void getBusinessLines_eachElementHasRequiredFields() {
+        // WHEN
+        ResponseEntity<BusinessLinesResponse> response = restClient.get()
+                .uri("/v1/business-lines")
+                .retrieve()
+                .toEntity(BusinessLinesResponse.class);
+
+        // THEN
+        assertThat(response.getBody()).isNotNull();
+        response.getBody().businessLines().forEach(bl -> {
+            assertThat(bl.code()).isNotBlank();
+            assertThat(bl.description()).isNotBlank();
+            assertThat(bl.fireKey()).isNotBlank();
+        });
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/BusinessLineControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/BusinessLineControllerTest.java
@@ -1,0 +1,71 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLineDto;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.mapper.BusinessLineRestMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BusinessLineControllerTest {
+
+    @Mock
+    private GetBusinessLinesUseCase getBusinessLinesUseCase;
+
+    @Mock
+    private BusinessLineRestMapper businessLineRestMapper;
+
+    @InjectMocks
+    private BusinessLineController controller;
+
+    @Test
+    void getBusinessLines_returnsHttp200WithBusinessLineList() {
+        // GIVEN
+        List<BusinessLine> businessLines = List.of(
+                new BusinessLine("BL-001", "Bodega de mercancías", "FK-INC-01")
+        );
+        BusinessLinesResponse response = new BusinessLinesResponse(
+                List.of(new BusinessLineDto("BL-001", "Bodega de mercancías", "FK-INC-01"))
+        );
+        when(getBusinessLinesUseCase.getAll()).thenReturn(businessLines);
+        when(businessLineRestMapper.toResponse(businessLines)).thenReturn(response);
+
+        // WHEN
+        ResponseEntity<BusinessLinesResponse> result = controller.getBusinessLines();
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().businessLines()).hasSize(1);
+        assertThat(result.getBody().businessLines().get(0).code()).isEqualTo("BL-001");
+        assertThat(result.getBody().businessLines().get(0).fireKey()).isEqualTo("FK-INC-01");
+    }
+
+    @Test
+    void getBusinessLines_delegatesToUseCaseAndMapper() {
+        // GIVEN
+        List<BusinessLine> businessLines = List.of();
+        when(getBusinessLinesUseCase.getAll()).thenReturn(businessLines);
+        when(businessLineRestMapper.toResponse(businessLines)).thenReturn(new BusinessLinesResponse(List.of()));
+
+        // WHEN
+        controller.getBusinessLines();
+
+        // THEN
+        verify(getBusinessLinesUseCase, times(1)).getAll();
+        verify(businessLineRestMapper, times(1)).toResponse(businessLines);
+        verifyNoMoreInteractions(getBusinessLinesUseCase, businessLineRestMapper);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/mapper/BusinessLineRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/in/rest/mapper/BusinessLineRestMapperTest.java
@@ -1,0 +1,44 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import com.sofka.insurancequoter.core.businessline.infrastructure.adapter.in.rest.dto.BusinessLinesResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BusinessLineRestMapperTest {
+
+    private final BusinessLineRestMapper mapper = new BusinessLineRestMapper();
+
+    @Test
+    void toResponse_mapsAllFieldsCorrectly() {
+        // GIVEN
+        List<BusinessLine> businessLines = List.of(
+                new BusinessLine("BL-001", "Bodega de mercancías", "FK-INC-01"),
+                new BusinessLine("BL-002", "Oficina administrativa", "FK-INC-02")
+        );
+
+        // WHEN
+        BusinessLinesResponse response = mapper.toResponse(businessLines);
+
+        // THEN
+        assertThat(response.businessLines()).hasSize(2);
+        assertThat(response.businessLines().get(0).code()).isEqualTo("BL-001");
+        assertThat(response.businessLines().get(0).description()).isEqualTo("Bodega de mercancías");
+        assertThat(response.businessLines().get(0).fireKey()).isEqualTo("FK-INC-01");
+        assertThat(response.businessLines().get(1).code()).isEqualTo("BL-002");
+        assertThat(response.businessLines().get(1).description()).isEqualTo("Oficina administrativa");
+        assertThat(response.businessLines().get(1).fireKey()).isEqualTo("FK-INC-02");
+    }
+
+    @Test
+    void toResponse_returnsEmptyBusinessLinesWhenListIsEmpty() {
+        // GIVEN / WHEN
+        BusinessLinesResponse response = mapper.toResponse(List.of());
+
+        // THEN
+        assertThat(response.businessLines()).isEmpty();
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/out/json/BusinessLineJsonAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/businessline/infrastructure/adapter/out/json/BusinessLineJsonAdapterTest.java
@@ -1,0 +1,76 @@
+package com.sofka.insurancequoter.core.businessline.infrastructure.adapter.out.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BusinessLineJsonAdapterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void findAll_returnsBusinessLinesFromJson() {
+        // GIVEN
+        String json = "[{\"code\":\"BL-001\",\"description\":\"Bodega de mercanc\\u00edas\",\"fireKey\":\"FK-INC-01\"},"
+                + "{\"code\":\"BL-002\",\"description\":\"Oficina administrativa\",\"fireKey\":\"FK-INC-02\"}]";
+        Resource resource = new ByteArrayResource(json.getBytes());
+
+        // WHEN
+        BusinessLineJsonAdapter adapter = new BusinessLineJsonAdapter(objectMapper, resource);
+        List<BusinessLine> result = adapter.findAll();
+
+        // THEN
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).code()).isEqualTo("BL-001");
+        assertThat(result.get(0).description()).isEqualTo("Bodega de mercancías");
+        assertThat(result.get(0).fireKey()).isEqualTo("FK-INC-01");
+        assertThat(result.get(1).code()).isEqualTo("BL-002");
+        assertThat(result.get(1).description()).isEqualTo("Oficina administrativa");
+        assertThat(result.get(1).fireKey()).isEqualTo("FK-INC-02");
+    }
+
+    @Test
+    void findAll_returnsEmptyListWhenJsonIsEmpty() {
+        // GIVEN
+        Resource resource = new ByteArrayResource("[]".getBytes());
+
+        // WHEN
+        BusinessLineJsonAdapter adapter = new BusinessLineJsonAdapter(objectMapper, resource);
+        List<BusinessLine> result = adapter.findAll();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findAll_returnsImmutableList() {
+        // GIVEN
+        String json = "[{\"code\":\"BL-001\",\"description\":\"Bodega de mercanc\\u00edas\",\"fireKey\":\"FK-INC-01\"}]";
+        BusinessLineJsonAdapter adapter = new BusinessLineJsonAdapter(objectMapper, new ByteArrayResource(json.getBytes()));
+
+        // WHEN
+        List<BusinessLine> result = adapter.findAll();
+
+        // THEN
+        assertThatThrownBy(() -> result.add(new BusinessLine("BL-999", "Test", "FK-999")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void constructor_throwsWhenResourceIsUnreadable() {
+        // GIVEN
+        Resource badResource = new ByteArrayResource("not-valid-json".getBytes());
+
+        // THEN
+        assertThatThrownBy(() -> new BusinessLineJsonAdapter(objectMapper, badResource))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to load business lines");
+    }
+}


### PR DESCRIPTION
## Descripción

Implementa el catálogo de giros de negocio (`GET /v1/business-lines`) en `Insurance-Quoter-Core`.

Los datos son estáticos: se cargan desde `fixtures/business-lines.json` en memoria al arrancar. No hay base de datos involucrada.

## Cambios

### Producción
- `BusinessLine` — domain record con `code`, `description`, `fireKey`
- `BusinessLineRepository` — output port (`findAll`)
- `GetBusinessLinesUseCase` — input port
- `GetBusinessLinesUseCaseImpl` — delega al output port
- `BusinessLineJsonAdapter` — carga JSON via ObjectMapper, fail-fast si el archivo es inválido
- `BusinessLineController` / `BusinessLineApi` — endpoint REST con Swagger separado
- `BusinessLineRestMapper`, `BusinessLineDto`, `BusinessLinesResponse` — mapeo a DTOs
- `BusinessLineConfig` — wiring de beans
- `fixtures/business-lines.json` — 5 giros de negocio con su clave incendio

### Tests
- `GetBusinessLinesUseCaseImplTest` — unitario Mockito
- `BusinessLineJsonAdapterTest` — unitario (happy path, vacío, fail-fast)
- `BusinessLineRestMapperTest` — unitario
- `BusinessLineControllerTest` — unitario
- `BusinessLineCatalogIntegrationTest` — `@SpringBootTest` + `RestClient`

### QA
- Matriz de riesgos: `docs/output/qa/business-lines-catalog-risks.md`
- Escenarios Gherkin: `docs/output/qa/business-lines-catalog-gherkin.md`
- Validación manual: `GET /v1/business-lines` → HTTP 200 ✅

## Issues cerrados

Closes #69, #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87

## Checklist

- [x] `./gradlew test` — BUILD SUCCESSFUL
- [x] Endpoint validado manualmente (HTTP 200, 5 giros con fireKey)
- [x] Sin `@Autowired`, Swagger solo en `swaggerdocs/`
- [x] Domain model sin anotaciones JPA ni Spring
- [x] Todos los issues del feature cerrados