### PR TITLE
feat: zip-codes catalog and validation endpoints (SPEC-005)

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -2,3 +2,5 @@
 
 - [folio-generator feature — implementation state](project_folio_feature.md) — SPEC-001 implementado, compila. Estructura de paquetes, decisiones de diseño y archivos clave.
 - [Insurance-Quoter-Core — setup y configuración base](project_core_setup.md) — Paquete base, puerto, DB, dependencias reales del proyecto core.
+- [Spring Boot 4 — RestClient.Builder no es bean automático](feedback_spring_boot4_restclient.md) — En tests de integración construir RestClient directamente en @BeforeEach, no inyectar con @Autowired.
+- [Testear @ExceptionHandler con Mockito puro](feedback_controller_exception_handler_test.md) — Llamar directamente al método handler; el dispatcher de Spring no está activo en tests Mockito puros.

--- a/.claude/agent-memory/backend-developer/feedback_controller_exception_handler_test.md
+++ b/.claude/agent-memory/backend-developer/feedback_controller_exception_handler_test.md
@@ -1,0 +1,23 @@
+---
+name: Testear @ExceptionHandler con Mockito puro — llamada directa al handler
+description: Con Mockito puro (sin Spring dispatcher), el @ExceptionHandler no se invoca al lanzar la excepción desde el use case. Se debe llamar directamente al método handler en el test.
+type: feedback
+---
+
+En los tests de controller con `@ExtendWith(MockitoExtension.class)` (sin Spring), si el controller tiene un `@ExceptionHandler`, este **no se invoca automáticamente** cuando el use case lanza la excepción.
+
+**Why:** Mockito instancia el controller como POJO; el mecanismo del DispatcherServlet que intercepta excepciones y llama al handler no está presente.
+
+**How to apply:** Testear el handler directamente:
+
+```java
+@Test
+void handleZipCodeNotFound_returns404WithStandardErrorBody() {
+    ZipCodeNotFoundException ex = new ZipCodeNotFoundException("99999");
+    ResponseEntity<Map<String, String>> result = controller.handleZipCodeNotFound(ex);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(result.getBody().get("code")).isEqualTo("ZIP_CODE_NOT_FOUND");
+}
+```
+
+El comportamiento end-to-end (excepción → 404 HTTP real) se cubre en el test de integración con `@SpringBootTest`.

--- a/.claude/agent-memory/backend-developer/feedback_spring_boot4_restclient.md
+++ b/.claude/agent-memory/backend-developer/feedback_spring_boot4_restclient.md
@@ -1,0 +1,22 @@
+---
+name: Spring Boot 4 — RestClient.Builder no es un bean automático
+description: En SB4 con spring-boot-starter-webmvc, RestClient.Builder no se registra como bean autoconfigured. Los tests de integración deben construir RestClient directamente.
+type: feedback
+---
+
+`RestClient.Builder` no está disponible como `@Autowired` en Spring Boot 4 con `spring-boot-starter-webmvc`.
+
+**Why:** La autoconfiguración de `RestClient.Builder` no existe en SB4 a diferencia de lo que ocurría en SB3.x con `RestTemplate` o `WebClient`.
+
+**How to apply:** En tests de integración con `@SpringBootTest(webEnvironment = RANDOM_PORT)`, construir el client directamente en `@BeforeEach`:
+
+```java
+@BeforeEach
+void setUp() {
+    client = RestClient.builder()
+            .baseUrl("http://localhost:" + port)
+            .build();
+}
+```
+
+No intentar inyectarlo con `@Autowired` ni con `RestClient.Builder`.

--- a/.claude/specs/zip-codes.spec.md
+++ b/.claude/specs/zip-codes.spec.md
@@ -1,0 +1,536 @@
+---
+id: SPEC-005
+status: DRAFT
+feature: zip-codes
+created: 2026-04-21
+updated: 2026-04-21
+author: spec-generator
+version: "1.0"
+related-specs: ["SPEC-001"]
+---
+
+# Spec: Consulta y Validación de Códigos Postales
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+El microservicio `Insurance-Quoter-Core` expone dos endpoints para el manejo de códigos postales (`zipCode`):
+
+- `GET /v1/zip-codes/{zipCode}` — retorna los datos completos de un código postal: estado, municipio, ciudad, colonias y zonas (catastrófica, TEV, FHM).
+- `POST /v1/zip-codes/validate` — indica si un código postal existe y es válido.
+
+Los datos se persisten en la tabla `zip_codes` de PostgreSQL (puerto 5433). Los datos iniciales se cargan mediante Flyway con la migración `V2__seed_zip_codes.sql`.
+
+`Insurance-Quoter-Back` utiliza estos endpoints para validar el código postal ingresado por el usuario durante el flujo de cotización y obtener las zonas necesarias para el cálculo de prima.
+
+### Requerimiento de Negocio
+
+> Consulta de códigos postales con sus zonas catastróficas, TEV y FHM almacenados en base de datos.
+> Dos endpoints: GET para obtener datos completos de un CP y POST para validar su existencia.
+> Datos iniciales cargados con Flyway. La tabla `zip_codes` es de solo lectura en runtime —
+> no se contemplan endpoints de escritura.
+
+### Historias de Usuario
+
+#### HU-01: Consultar datos de un código postal
+
+```
+Como:        sistema cliente (Insurance-Quoter-Back u otro consumidor)
+Quiero:      llamar GET /v1/zip-codes/{zipCode} y recibir los datos completos del CP
+Para:        mostrar al usuario las colonias disponibles y obtener las zonas
+             necesarias para el cálculo de prima (catastrófica, TEV, FHM)
+
+Prioridad:   Alta
+Estimación:  M
+Dependencias: Flyway V2 con datos seed en DB
+Capa:        Backend
+```
+
+#### HU-02: Validar existencia de un código postal
+
+```
+Como:        sistema cliente (Insurance-Quoter-Back)
+Quiero:      llamar POST /v1/zip-codes/validate con un código postal
+Para:        confirmar que el CP es válido antes de continuar el flujo de cotización
+             y evitar crear folios con CPs inexistentes
+
+Prioridad:   Alta
+Estimación:  S
+Dependencias: HU-01 (mismo repositorio y tabla)
+Capa:        Backend
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Retorno de datos completos de un CP existente
+  Dado que:  el código postal "06600" existe en la base de datos
+  Cuando:    se realiza GET /v1/zip-codes/06600
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "zipCode": "06600"
+             Y contiene "state", "municipality", "city" con valores no vacíos
+             Y contiene "neighborhoods" como array con al menos una colonia
+             Y contiene "catastrophicZone", "tevZone", "fhmZone" con valores no vacíos
+             Y contiene "valid": true
+```
+
+**CP no encontrado**
+```gherkin
+CRITERIO-1.2: CP inexistente retorna 404
+  Dado que:  el código postal "99999" NO existe en la base de datos
+  Cuando:    se realiza GET /v1/zip-codes/99999
+  Entonces:  la respuesta tiene HTTP 404
+             Y el cuerpo contiene "error": "Zip code not found"
+             Y contiene "code": "ZIP_CODE_NOT_FOUND"
+```
+
+**CP con formato inválido**
+```gherkin
+CRITERIO-1.3: CP con formato inválido retorna 400
+  Dado que:  el valor "ABC" no es un código postal válido (no es numérico de 5 dígitos)
+  Cuando:    se realiza GET /v1/zip-codes/ABC
+  Entonces:  la respuesta tiene HTTP 400
+             Y el cuerpo contiene un mensaje de error descriptivo
+```
+
+#### Criterios de Aceptación — HU-02
+
+**CP válido**
+```gherkin
+CRITERIO-2.1: Validación exitosa de CP existente
+  Dado que:  el código postal "06600" existe en la base de datos
+  Cuando:    se realiza POST /v1/zip-codes/validate con body { "zipCode": "06600" }
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "valid": true
+             Y contiene "zipCode": "06600"
+```
+
+**CP inválido**
+```gherkin
+CRITERIO-2.2: Validación de CP inexistente
+  Dado que:  el código postal "99999" NO existe en la base de datos
+  Cuando:    se realiza POST /v1/zip-codes/validate con body { "zipCode": "99999" }
+  Entonces:  la respuesta tiene HTTP 200
+             Y el cuerpo contiene "valid": false
+             Y contiene "zipCode": "99999"
+```
+
+**Request sin zipCode**
+```gherkin
+CRITERIO-2.3: Request sin campo zipCode retorna 400
+  Dado que:  se envía un body vacío o sin el campo "zipCode"
+  Cuando:    se realiza POST /v1/zip-codes/validate
+  Entonces:  la respuesta tiene HTTP 400
+```
+
+### Reglas de Negocio
+
+| ID   | Regla |
+|------|-------|
+| RN-1 | La tabla `zip_codes` es de solo lectura en runtime — no existen endpoints de creación, modificación ni eliminación. |
+| RN-2 | Las colonias (`neighborhoods`) se almacenan en una tabla separada `zip_code_neighborhoods` con FK a `zip_codes`. |
+| RN-3 | Un CP puede tener cero o más colonias asociadas. |
+| RN-4 | `GET /v1/zip-codes/{zipCode}` retorna 404 si el CP no existe; nunca retorna null en campos de zona. |
+| RN-5 | `POST /v1/zip-codes/validate` siempre retorna HTTP 200; el campo `valid` indica la existencia. |
+| RN-6 | Los valores de zona (`catastrophicZone`, `tevZone`, `fhmZone`) son strings opacos definidos por negocio (ej. `ZONE_A`, `TEV-1`, `FHM-2`). |
+| RN-7 | El endpoint no requiere autenticación — es un servicio interno consumido por `Insurance-Quoter-Back`. |
+| RN-8 | Los datos seed de `V2__seed_zip_codes.sql` deben incluir al menos 5 CPs representativos de distintos estados y zonas. |
+
+---
+
+## 2. DISEÑO
+
+### Modelo de Dominio
+
+#### `ZipCode` — domain model (POJO puro, sin anotaciones JPA ni Spring)
+
+```java
+// com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode
+public record ZipCode(
+    String zipCode,
+    String state,
+    String municipality,
+    String city,
+    List<String> neighborhoods,
+    String catastrophicZone,
+    String tevZone,
+    String fhmZone
+) {}
+```
+
+| Campo              | Tipo           | Restricciones                                              |
+|--------------------|----------------|------------------------------------------------------------|
+| `zipCode`          | String         | No nulo, no vacío — 5 dígitos numéricos (ej. `06600`)     |
+| `state`            | String         | No nulo, no vacío                                          |
+| `municipality`     | String         | No nulo, no vacío                                          |
+| `city`             | String         | No nulo, no vacío                                          |
+| `neighborhoods`    | List\<String\> | No nulo — puede estar vacío                                |
+| `catastrophicZone` | String         | No nulo, no vacío (ej. `ZONE_A`)                           |
+| `tevZone`          | String         | No nulo, no vacío (ej. `TEV-1`)                            |
+| `fhmZone`          | String         | No nulo, no vacío (ej. `FHM-2`)                            |
+
+### Output Port
+
+```java
+// com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository
+public interface ZipCodeRepository {
+    Optional<ZipCode> findByZipCode(String zipCode);
+}
+```
+
+### Input Ports (Use Cases)
+
+```java
+// com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase
+public interface GetZipCodeUseCase {
+    ZipCode getByZipCode(String zipCode);
+}
+
+// com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase
+public interface ValidateZipCodeUseCase {
+    ZipCodeValidationResult validate(String zipCode);
+}
+```
+
+> `ZipCodeValidationResult` es un record en el dominio: `record ZipCodeValidationResult(boolean valid, String zipCode) {}`
+> `GetZipCodeUseCase` lanza `ZipCodeNotFoundException` (excepción de dominio) cuando el CP no existe.
+
+### Modelo de Datos — Esquema PostgreSQL
+
+#### Tabla `zip_codes`
+
+```sql
+CREATE TABLE zip_codes (
+    zip_code         VARCHAR(10)  PRIMARY KEY,
+    state            VARCHAR(100) NOT NULL,
+    municipality     VARCHAR(100) NOT NULL,
+    city             VARCHAR(100) NOT NULL,
+    catastrophic_zone VARCHAR(20) NOT NULL,
+    tev_zone         VARCHAR(20)  NOT NULL,
+    fhm_zone         VARCHAR(20)  NOT NULL
+);
+```
+
+#### Tabla `zip_code_neighborhoods`
+
+```sql
+CREATE TABLE zip_code_neighborhoods (
+    id               BIGSERIAL    PRIMARY KEY,
+    zip_code         VARCHAR(10)  NOT NULL REFERENCES zip_codes(zip_code),
+    neighborhood     VARCHAR(150) NOT NULL
+);
+
+CREATE INDEX idx_zip_code_neighborhoods_zip_code ON zip_code_neighborhoods(zip_code);
+```
+
+> Las migraciones se crean en `src/main/resources/db/migration/`:
+> - `V2__create_zip_codes.sql` — DDL de las dos tablas
+> - `V3__seed_zip_codes.sql` — datos iniciales representativos
+
+### Entidades JPA
+
+#### `ZipCodeJpa`
+
+```java
+// infrastructure/adapter/out/persistence/entity/ZipCodeJpa.java
+@Entity
+@Table(name = "zip_codes")
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+public class ZipCodeJpa {
+
+    @Id
+    @Column(name = "zip_code", nullable = false, length = 10)
+    private String zipCode;
+
+    @Column(name = "state", nullable = false, length = 100)
+    private String state;
+
+    @Column(name = "municipality", nullable = false, length = 100)
+    private String municipality;
+
+    @Column(name = "city", nullable = false, length = 100)
+    private String city;
+
+    @Column(name = "catastrophic_zone", nullable = false, length = 20)
+    private String catastrophicZone;
+
+    @Column(name = "tev_zone", nullable = false, length = 20)
+    private String tevZone;
+
+    @Column(name = "fhm_zone", nullable = false, length = 20)
+    private String fhmZone;
+
+    @OneToMany(mappedBy = "zipCode", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ZipCodeNeighborhoodJpa> neighborhoods;
+}
+```
+
+#### `ZipCodeNeighborhoodJpa`
+
+```java
+// infrastructure/adapter/out/persistence/entity/ZipCodeNeighborhoodJpa.java
+@Entity
+@Table(name = "zip_code_neighborhoods")
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+public class ZipCodeNeighborhoodJpa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "zip_code", nullable = false)
+    private ZipCodeJpa zipCode;
+
+    @Column(name = "neighborhood", nullable = false, length = 150)
+    private String neighborhood;
+}
+```
+
+### Spring Data JPA Repository
+
+```java
+// infrastructure/adapter/out/persistence/ZipCodeJpaRepository.java
+public interface ZipCodeJpaRepository extends JpaRepository<ZipCodeJpa, String> {
+
+    @Query("SELECT z FROM ZipCodeJpa z LEFT JOIN FETCH z.neighborhoods WHERE z.zipCode = :zipCode")
+    Optional<ZipCodeJpa> findByZipCodeWithNeighborhoods(@Param("zipCode") String zipCode);
+}
+```
+
+> Se usa `JOIN FETCH` para evitar N+1 al cargar colonias.
+
+### Excepciones de dominio
+
+```java
+// domain/exception/ZipCodeNotFoundException.java
+public class ZipCodeNotFoundException extends RuntimeException {
+    public ZipCodeNotFoundException(String zipCode) {
+        super("Zip code not found: " + zipCode);
+    }
+}
+```
+
+### API Endpoints
+
+#### `GET /v1/zip-codes/{zipCode}`
+
+| Atributo   | Valor                         |
+|------------|-------------------------------|
+| Método     | `GET`                         |
+| Ruta       | `/v1/zip-codes/{zipCode}`     |
+| Auth       | Ninguna (servicio interno)    |
+| Produces   | `application/json`            |
+
+**Response 200:**
+```json
+{
+  "zipCode": "06600",
+  "state": "Ciudad de México",
+  "municipality": "Cuauhtémoc",
+  "city": "Ciudad de México",
+  "neighborhoods": ["Juárez", "Tabacalera"],
+  "catastrophicZone": "ZONE_A",
+  "tevZone": "TEV-1",
+  "fhmZone": "FHM-2",
+  "valid": true
+}
+```
+
+**Response 404:**
+```json
+{ "error": "Zip code not found", "code": "ZIP_CODE_NOT_FOUND" }
+```
+
+**Response 400** (formato inválido):
+```json
+{ "error": "Invalid zip code format", "code": "INVALID_ZIP_CODE_FORMAT" }
+```
+
+#### `POST /v1/zip-codes/validate`
+
+| Atributo   | Valor                            |
+|------------|----------------------------------|
+| Método     | `POST`                           |
+| Ruta       | `/v1/zip-codes/validate`         |
+| Auth       | Ninguna (servicio interno)       |
+| Consumes   | `application/json`               |
+| Produces   | `application/json`               |
+
+**Request:**
+```json
+{ "zipCode": "06600" }
+```
+
+**Response 200 — CP válido:**
+```json
+{ "valid": true, "zipCode": "06600" }
+```
+
+**Response 200 — CP inválido:**
+```json
+{ "valid": false, "zipCode": "99999" }
+```
+
+**Response 400** (body sin `zipCode`):
+```json
+{ "error": "zipCode is required", "code": "MISSING_FIELD" }
+```
+
+### DTOs REST
+
+```java
+// dto de response para GET
+public record ZipCodeResponse(
+    String zipCode,
+    String state,
+    String municipality,
+    String city,
+    List<String> neighborhoods,
+    String catastrophicZone,
+    String tevZone,
+    String fhmZone,
+    boolean valid
+) {}
+
+// dto de request para POST /validate
+public record ValidateZipCodeRequest(@NotBlank String zipCode) {}
+
+// dto de response para POST /validate
+public record ZipCodeValidationResponse(boolean valid, String zipCode) {}
+```
+
+### Manejo de errores
+
+El controller captura `ZipCodeNotFoundException` y retorna HTTP 404 con el cuerpo estándar de error:
+`{ "error": "Zip code not found", "code": "ZIP_CODE_NOT_FOUND" }`.
+
+Alternativamente, puede manejarse en un `@RestControllerAdvice` global.
+
+### Arquitectura Hexagonal — estructura de paquetes
+
+```
+com.sofka.insurancequoter.core.zipcode/
+├── domain/
+│   ├── model/
+│   │   ├── ZipCode.java                                    ← record puro
+│   │   └── ZipCodeValidationResult.java                   ← record puro
+│   ├── exception/
+│   │   └── ZipCodeNotFoundException.java                  ← excepción de dominio
+│   └── port/
+│       ├── in/
+│       │   ├── GetZipCodeUseCase.java                     ← input port
+│       │   └── ValidateZipCodeUseCase.java                ← input port
+│       └── out/
+│           └── ZipCodeRepository.java                     ← output port
+├── application/
+│   └── usecase/
+│       ├── GetZipCodeUseCaseImpl.java                     ← sin @Service, wired via @Bean
+│       └── ValidateZipCodeUseCaseImpl.java                ← sin @Service, wired via @Bean
+└── infrastructure/
+    ├── adapter/
+    │   ├── in/
+    │   │   └── rest/
+    │   │       ├── swaggerdocs/
+    │   │       │   └── ZipCodeApi.java                    ← @Tag, @Operation
+    │   │       ├── ZipCodeController.java                 ← implements ZipCodeApi
+    │   │       ├── dto/
+    │   │       │   ├── ZipCodeResponse.java
+    │   │       │   ├── ValidateZipCodeRequest.java
+    │   │       │   └── ZipCodeValidationResponse.java
+    │   │       └── mapper/
+    │   │           └── ZipCodeRestMapper.java
+    │   └── out/
+    │       └── persistence/
+    │           ├── entity/
+    │           │   ├── ZipCodeJpa.java
+    │           │   └── ZipCodeNeighborhoodJpa.java
+    │           ├── ZipCodeJpaRepository.java              ← Spring Data JPA
+    │           └── ZipCodePersistenceAdapter.java         ← implementa ZipCodeRepository
+    └── config/
+        └── ZipCodeConfig.java                             ← @Bean wiring
+```
+
+### Migraciones Flyway
+
+```
+src/main/resources/db/migration/
+├── V1__create_folio_sequence.sql   ← ya existe
+├── V2__create_zip_codes.sql        ← DDL de zip_codes y zip_code_neighborhoods
+└── V3__seed_zip_codes.sql          ← datos seed representativos (≥5 CPs, distintos estados y zonas)
+```
+
+**Datos seed mínimos para `V3__seed_zip_codes.sql`:**
+
+| zip_code | state | municipality | city | catastrophic_zone | tev_zone | fhm_zone |
+|----------|-------|-------------|------|-------------------|----------|----------|
+| 06600 | Ciudad de México | Cuauhtémoc | Ciudad de México | ZONE_A | TEV-1 | FHM-2 |
+| 44100 | Jalisco | Guadalajara | Guadalajara | ZONE_B | TEV-2 | FHM-1 |
+| 64000 | Nuevo León | Monterrey | Monterrey | ZONE_C | TEV-3 | FHM-3 |
+| 72000 | Puebla | Puebla | Puebla | ZONE_B | TEV-2 | FHM-2 |
+| 20000 | Aguascalientes | Aguascalientes | Aguascalientes | ZONE_D | TEV-4 | FHM-1 |
+
+Colonias de ejemplo para `06600`: `Juárez`, `Tabacalera`.
+
+---
+
+## 3. LISTA DE TAREAS
+
+### Base de Datos
+
+- [ ] **TASK-1** Crear migración `V2__create_zip_codes.sql` — DDL de las tablas `zip_codes` y `zip_code_neighborhoods` con índice en FK
+- [ ] **TASK-2** Crear migración `V3__seed_zip_codes.sql` — datos seed de al menos 5 CPs representativos con colonias para `06600`
+
+### Backend — Dominio
+
+- [ ] **TASK-3** Crear domain model `ZipCode` (record Java, sin anotaciones)
+- [ ] **TASK-4** Crear domain model `ZipCodeValidationResult` (record Java)
+- [ ] **TASK-5** Crear excepción de dominio `ZipCodeNotFoundException`
+- [ ] **TASK-6** Crear output port `ZipCodeRepository` con método `findByZipCode(String): Optional<ZipCode>`
+- [ ] **TASK-7** Crear input port `GetZipCodeUseCase` con método `getByZipCode(String): ZipCode`
+- [ ] **TASK-8** Crear input port `ValidateZipCodeUseCase` con método `validate(String): ZipCodeValidationResult`
+
+### Backend — Aplicación
+
+- [ ] **TASK-9** Implementar `GetZipCodeUseCaseImpl` — llama a `ZipCodeRepository.findByZipCode`, lanza `ZipCodeNotFoundException` si no existe
+- [ ] **TASK-10** Implementar `ValidateZipCodeUseCaseImpl` — llama a `ZipCodeRepository.findByZipCode`, retorna `ZipCodeValidationResult(valid, zipCode)`
+
+### Backend — Persistencia
+
+- [ ] **TASK-11** Crear entidad JPA `ZipCodeJpa` (tabla `zip_codes`) con relación `@OneToMany` a `ZipCodeNeighborhoodJpa`
+- [ ] **TASK-12** Crear entidad JPA `ZipCodeNeighborhoodJpa` (tabla `zip_code_neighborhoods`) con `@ManyToOne` a `ZipCodeJpa`
+- [ ] **TASK-13** Crear `ZipCodeJpaRepository` con método `findByZipCodeWithNeighborhoods` usando `JOIN FETCH`
+- [ ] **TASK-14** Implementar `ZipCodePersistenceAdapter` — implementa `ZipCodeRepository`, mapea `ZipCodeJpa` → `ZipCode`
+
+### Backend — REST
+
+- [ ] **TASK-15** Crear DTOs REST: `ZipCodeResponse`, `ValidateZipCodeRequest`, `ZipCodeValidationResponse`
+- [ ] **TASK-16** Crear `ZipCodeRestMapper` — mapea `ZipCode` → `ZipCodeResponse` y `ZipCodeValidationResult` → `ZipCodeValidationResponse`
+- [ ] **TASK-17** Crear interfaz Swagger `ZipCodeApi` (en `rest/swaggerdocs/`)
+- [ ] **TASK-18** Crear `ZipCodeController` — implementa `ZipCodeApi`, captura `ZipCodeNotFoundException` → 404
+
+### Backend — Configuración
+
+- [ ] **TASK-19** Crear `ZipCodeConfig` — registra `GetZipCodeUseCaseImpl` y `ValidateZipCodeUseCaseImpl` como `@Bean`
+
+### Tests (TDD — escribir antes de implementar)
+
+- [ ] **TASK-20** Test unitario `GetZipCodeUseCaseImplTest` — CP existente retorna `ZipCode`, CP inexistente lanza `ZipCodeNotFoundException`
+- [ ] **TASK-21** Test unitario `ValidateZipCodeUseCaseImplTest` — CP existente retorna `valid: true`, CP inexistente retorna `valid: false`
+- [ ] **TASK-22** Test unitario `ZipCodePersistenceAdapterTest` — verifica mapeo `ZipCodeJpa` → `ZipCode` (con y sin colonias)
+- [ ] **TASK-23** Test unitario `ZipCodeRestMapperTest` — verifica mapeo `ZipCode` → `ZipCodeResponse` y `ZipCodeValidationResult` → `ZipCodeValidationResponse`
+- [ ] **TASK-24** Test unitario `ZipCodeControllerTest` — GET 200, GET 404, POST validate 200 (valid/invalid)
+- [ ] **TASK-25** Test de integración `ZipCodeIntegrationTest` (`@SpringBootTest` + `@Testcontainers`) — GET CP existente, GET CP inexistente 404, POST validate true, POST validate false
+
+### QA
+
+- [ ] **TASK-26** Ejecutar `/risk-identifier` para generar matriz de riesgos `zip-codes-risks.md`
+- [ ] **TASK-27** Ejecutar `/gherkin-case-generator` para generar escenarios Gherkin `zip-codes-gherkin.md`
+- [ ] **TASK-28** Validar endpoints manualmente con curl o Swagger UI (`http://localhost:8081/swagger-ui/index.html`)

--- a/.claude/specs/zip-codes.spec.md
+++ b/.claude/specs/zip-codes.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-005
-status: DRAFT
+status: IMPLEMENTED
 feature: zip-codes
 created: 2026-04-21
 updated: 2026-04-21

--- a/docs/output/qa/zip-codes-gherkin.md
+++ b/docs/output/qa/zip-codes-gherkin.md
@@ -1,0 +1,190 @@
+# Escenarios Gherkin — Códigos Postales (SPEC-005)
+
+**Feature:** zip-codes  
+**Microservicio:** Insurance-Quoter-Core · `GET /v1/zip-codes/{zipCode}` · `POST /v1/zip-codes/validate`  
+**Fecha:** 2026-04-21
+
+---
+
+```gherkin
+#language: es
+Característica: Consulta y validación de códigos postales con zonas catastróficas
+
+  Como sistema de cotización de seguros
+  Quiero consultar y validar códigos postales
+  Para obtener las zonas necesarias para el cálculo de prima y verificar la existencia del CP
+
+  Antecedentes:
+    Dado que el microservicio Insurance-Quoter-Core está disponible en el puerto 8081
+    Y la base de datos contiene el código postal "06600" en "Ciudad de México" con zona catastrófica "ZONE_A"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-01: CONSULTA DE CÓDIGO POSTAL — HAPPY PATH
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @smoke @critico @happy-path
+  Escenario: Consulta exitosa de un código postal existente con todos sus datos
+    Dado que el código postal "06600" existe en la base de datos
+    Cuando el sistema cliente solicita los datos del código postal "06600"
+    Entonces la respuesta tiene estado HTTP 200
+    Y la respuesta contiene el código postal "06600"
+    Y contiene el estado "Ciudad de México"
+    Y contiene el municipio "Cuauhtémoc"
+    Y contiene la ciudad "Ciudad de México"
+    Y contiene al menos una colonia en el listado de colonias
+    Y contiene la zona catastrófica "ZONE_A"
+    Y contiene la zona TEV "TEV-1"
+    Y contiene la zona FHM "FHM-2"
+    Y el campo "valid" es verdadero
+
+  @smoke @critico @happy-path
+  Escenario: El catálogo retorna las colonias asociadas al código postal
+    Dado que el código postal "06600" tiene las colonias "Juárez" y "Tabacalera" registradas
+    Cuando el sistema cliente solicita los datos del código postal "06600"
+    Entonces la respuesta contiene la colonia "Juárez" en el listado de colonias
+    Y contiene la colonia "Tabacalera" en el listado de colonias
+
+  @smoke @critico @happy-path
+  Escenario: Consulta de código postal de otra ciudad retorna su zona correcta
+    Dado que el código postal "64000" existe en la base de datos con zona catastrófica "ZONE_C"
+    Cuando el sistema cliente solicita los datos del código postal "64000"
+    Entonces la respuesta tiene estado HTTP 200
+    Y contiene el estado "Nuevo León"
+    Y contiene la zona catastrófica "ZONE_C"
+    Y contiene la zona TEV "TEV-3"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-01: CONSULTA DE CÓDIGO POSTAL — ERROR PATH
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @error-path
+  Escenario: Consulta de código postal inexistente retorna error 404
+    Dado que el código postal "99999" no existe en la base de datos
+    Cuando el sistema cliente solicita los datos del código postal "99999"
+    Entonces la respuesta tiene estado HTTP 404
+    Y la respuesta contiene el mensaje de error "Zip code not found"
+    Y contiene el código de error "ZIP_CODE_NOT_FOUND"
+
+  @error-path
+  Escenario: Consulta con código postal de formato inválido retorna error 400
+    Dado que "ABC" no es un código postal válido
+    Cuando el sistema cliente solicita los datos del código postal "ABC"
+    Entonces la respuesta tiene estado HTTP 400
+    Y la respuesta contiene un mensaje de error descriptivo
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-01: CONSULTA DE CÓDIGO POSTAL — EDGE CASES
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @edge-case
+  Escenario: Código postal existente sin colonias retorna lista vacía
+    Dado que el código postal "20000" existe en la base de datos pero no tiene colonias registradas
+    Cuando el sistema cliente solicita los datos del código postal "20000"
+    Entonces la respuesta tiene estado HTTP 200
+    Y el listado de colonias está vacío
+    Y todos los campos de zona contienen valores no vacíos
+
+  @edge-case
+  Escenario: La respuesta siempre incluye el campo "valid" en true para CP existente
+    Dado que el código postal "44100" existe en la base de datos
+    Cuando el sistema cliente solicita los datos del código postal "44100"
+    Entonces la respuesta contiene el campo "valid" con valor verdadero
+
+  @edge-case
+  Esquema del escenario: Consulta de códigos postales de distintas zonas catastróficas
+    Dado que el código postal "<cp>" existe con zona catastrófica "<zona>"
+    Cuando el sistema cliente consulta ese código postal
+    Entonces la respuesta tiene estado HTTP 200
+    Y contiene la zona catastrófica "<zona>"
+
+    Ejemplos:
+      | cp    | zona   |
+      | 06600 | ZONE_A |
+      | 44100 | ZONE_B |
+      | 64000 | ZONE_C |
+      | 20000 | ZONE_D |
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-02: VALIDACIÓN DE CÓDIGO POSTAL — HAPPY PATH
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @smoke @critico @happy-path
+  Escenario: Validación exitosa de código postal existente
+    Dado que el código postal "06600" existe en la base de datos
+    Cuando el sistema cliente valida el código postal "06600"
+    Entonces la respuesta tiene estado HTTP 200
+    Y la respuesta contiene "valid" con valor verdadero
+    Y contiene el código postal "06600"
+
+  @smoke @critico @happy-path
+  Escenario: Validación de código postal inexistente retorna valid false con HTTP 200
+    Dado que el código postal "99999" no existe en la base de datos
+    Cuando el sistema cliente valida el código postal "99999"
+    Entonces la respuesta tiene estado HTTP 200
+    Y la respuesta contiene "valid" con valor falso
+    Y contiene el código postal "99999"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-02: VALIDACIÓN DE CÓDIGO POSTAL — ERROR PATH
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @error-path
+  Escenario: Validación sin código postal en el body retorna error 400
+    Dado que el sistema cliente envía una solicitud de validación sin el campo código postal
+    Cuando se intenta validar el código postal
+    Entonces la respuesta tiene estado HTTP 400
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # HU-02: VALIDACIÓN DE CÓDIGO POSTAL — EDGE CASES
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  @edge-case
+  Escenario: La validación siempre retorna HTTP 200 independientemente de si el CP existe
+    Dado que el sistema cliente tiene un código postal para validar
+    Cuando valida un código postal existente "06600"
+    Entonces la respuesta tiene estado HTTP 200
+    Cuando valida un código postal inexistente "99999"
+    Entonces la respuesta tiene estado HTTP 200
+
+  @edge-case
+  Esquema del escenario: Validación de múltiples códigos postales
+    Dado que el código postal "<cp>" "<existe>" en la base de datos
+    Cuando el sistema cliente valida el código postal "<cp>"
+    Entonces la respuesta contiene "valid" con valor "<resultado>"
+
+    Ejemplos:
+      | cp    | existe       | resultado |
+      | 06600 | existe       | true      |
+      | 44100 | existe       | true      |
+      | 11111 | no existe    | false     |
+      | 00000 | no existe    | false     |
+```
+
+---
+
+## Datos de Prueba Sintéticos
+
+| Escenario                          | Campo              | Válido                   | Inválido  | Borde               |
+|------------------------------------|--------------------|--------------------------|-----------|---------------------|
+| Consulta CP existente              | `zipCode` (path)   | `06600`, `44100`, `64000`| `99999`   | `00000`             |
+| Consulta CP — formato              | `zipCode` (path)   | `06600`                  | `ABC`, `` | `0` (1 dígito)      |
+| CP sin colonias                    | `neighborhoods`    | `[]`                     | —         | —                   |
+| Zona catastrófica                  | `catastrophicZone` | `ZONE_A`..`ZONE_D`       | —         | —                   |
+| Validación — body request          | `zipCode` (body)   | `{"zipCode":"06600"}`    | `{}`      | `{"zipCode":""}`    |
+| Validación — CP existente          | `valid`            | `true`                   | —         | —                   |
+| Validación — CP inexistente        | `valid`            | `false`                  | —         | —                   |
+
+---
+
+## Flujos Críticos Identificados
+
+| Flujo | Tipo | Tags | Prioridad |
+|-------|------|------|-----------|
+| GET CP existente con todas las zonas | Happy path | `@smoke @critico` | Alta — zonas impactan prima |
+| GET CP con colonias correctas | Happy path | `@smoke @critico` | Alta — N+1 risk |
+| GET CP inexistente → 404 con código de error | Error path | `@error-path` | Alta — contrato con Back |
+| POST validate CP existente → 200 valid:true | Happy path | `@smoke @critico` | Alta |
+| POST validate CP inexistente → 200 valid:false | Happy path | `@smoke @critico` | Alta — RN-5 |
+| GET CP sin colonias → array vacío | Edge case | `@edge-case` | Media |
+| POST validate sin body → 400 | Error path | `@error-path` | Media |
+| Distintas zonas catastróficas | Edge case | `@edge-case` | Media — cobertura de zonas |

--- a/docs/output/qa/zip-codes-risks.md
+++ b/docs/output/qa/zip-codes-risks.md
@@ -1,0 +1,87 @@
+# Matriz de Riesgos — Códigos Postales (SPEC-005)
+
+**Feature:** zip-codes  
+**Microservicio:** Insurance-Quoter-Core (puerto 8081)  
+**Fecha:** 2026-04-21
+
+---
+
+## Resumen
+
+Total: 8 | Alto (A): 3 | Medio (S): 4 | Bajo (D): 1
+
+---
+
+## Detalle
+
+| ID    | HU     | Descripción del Riesgo                                                                        | Factores                                                        | Nivel | Testing      |
+|-------|--------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------------|-------|--------------|
+| R-001 | HU-01  | `catastrophicZone`, `tevZone` o `fhmZone` incorrectos en seed → cálculo de prima erróneo     | Dato crítico para cálculo financiero; gestionado por migración  | A     | Obligatorio  |
+| R-002 | HU-01  | Problema N+1 al cargar colonias sin `JOIN FETCH` → degradación severa bajo carga             | Alta frecuencia de uso; consulta en cada cotización             | A     | Obligatorio  |
+| R-003 | HU-01/02 | Migración Flyway falla en deploy → servicio no arranca; bloquea todo el flujo de cotización | Integridad del contexto Spring; dependencia de DB externa       | A     | Obligatorio  |
+| R-004 | HU-01  | GET retorna 200 con campos nulos si el mapeo JPA → domain falla silenciosamente              | Código nuevo sin historial; múltiples capas de mapeo            | S     | Recomendado  |
+| R-005 | HU-02  | POST /validate retorna HTTP distinto de 200 para CP inexistente (viola RN-5)                 | Lógica de negocio específica; ruptura de contrato con Back      | S     | Recomendado  |
+| R-006 | HU-01  | CP con colonias en distintos estados simultáneos rompe consistencia de `neighborhoods`       | Lógica de negocio compleja; relación `@OneToMany` con LAZY load | S     | Recomendado  |
+| R-007 | HU-01/02 | Datos seed insuficientes o sin representación de todas las zonas catastróficas             | Código nuevo; cobertura de datos de prueba                      | S     | Recomendado  |
+| R-008 | HU-01  | Formato del `zipCode` no validado en el path variable (ej. cadena larga o con caracteres especiales) | Feature interno; impacto limitado a llamadas malformadas   | D     | Opcional     |
+
+---
+
+## Plan de Mitigación — Riesgos ALTO
+
+### R-001: Datos de zona incorrectos en seed afectan el cálculo de prima
+
+- **Contexto:** Los valores `catastrophicZone`, `tevZone` y `fhmZone` que entrega este endpoint son consumidos directamente por `Insurance-Quoter-Back` para calcular la prima. Un seed erróneo produce cálculos incorrectos sin error visible en runtime.
+- **Mitigación:**
+  - Revisar el archivo `V3__seed_zip_codes.sql` en cada PR que lo modifique.
+  - Añadir aserción en `ZipCodeIntegrationTest` que verifique los valores de zona del CP `06600` contra los valores esperados del seed.
+  - Considerar validación defensiva en `ZipCodePersistenceAdapter` que rechace registros con zonas vacías.
+- **Tests obligatorios:**
+  - Test de integración: verificar que `GET /v1/zip-codes/06600` retorna `catastrophicZone=ZONE_A`, `tevZone=TEV-1`, `fhmZone=FHM-2`.
+  - Test unitario de mapper: verificar que ningún campo de zona se mapea a null.
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+### R-002: Problema N+1 al cargar colonias
+
+- **Contexto:** Sin `JOIN FETCH`, Hibernate ejecuta una query por cada CP para cargar sus colonias. En un endpoint consultado en cada cotización, esto puede producir cientos de queries por segundo bajo carga media.
+- **Mitigación:**
+  - Verificar que `ZipCodeJpaRepository.findByZipCodeWithNeighborhoods` usa `LEFT JOIN FETCH z.neighborhoods`.
+  - Activar `spring.jpa.show-sql=true` en test de integración y verificar que se ejecuta exactamente 1 query al llamar el endpoint.
+  - Añadir `@BatchSize` como fallback si en el futuro se usa `findAll()`.
+- **Tests obligatorios:**
+  - Test de integración: llamar `GET /v1/zip-codes/06600` y verificar que `neighborhoods` contiene los valores esperados (prueba indirecta de que el fetch funcionó).
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+### R-003: Fallo de migración Flyway bloquea el arranque
+
+- **Contexto:** Si `V2__create_zip_codes.sql` o `V3__seed_zip_codes.sql` tienen errores SQL, la aplicación no arranca. Esto afecta no solo a `zip-codes` sino a todo el microservicio.
+- **Mitigación:**
+  - El test de integración `ZipCodeIntegrationTest` con Testcontainers valida implícitamente que las migraciones corren sin error (el contexto Spring levanta).
+  - Ejecutar `./gradlew test` antes de cualquier merge — si las migraciones fallan, el test de integración falla primero.
+  - Revisar el orden de versiones Flyway: V1 ya existe, V2 y V3 deben ser consecutivas.
+- **Tests obligatorios:**
+  - Test de integración: contexto Spring arranca correctamente con Testcontainers (cualquier fallo de Flyway revienta este test).
+- **Bloqueante para release:** ✅ Sí
+
+---
+
+## Riesgos MEDIO — Acciones Recomendadas
+
+### R-004: Campos nulos por fallo silencioso en mapeo JPA → domain
+- Añadir assertion en `ZipCodePersistenceAdapterTest` que verifique que ningún campo del `ZipCode` resultante es null.
+- El test de integración que verifica todos los campos del response actúa como red de seguridad.
+
+### R-005: POST /validate viola RN-5 si retorna non-200 para CP inexistente
+- Cubrir explícitamente en `ZipCodeControllerTest` y en `ZipCodeIntegrationTest` el caso de CP inexistente en POST /validate → debe retornar HTTP 200 con `valid: false`.
+
+### R-006: Consistencia de `neighborhoods` con carga LAZY
+- Verificar en `ZipCodeIntegrationTest` que el array `neighborhoods` no es null y contiene los valores del seed para `06600`.
+- La relación `@OneToMany` con `LAZY` + `JOIN FETCH` en la query es la estrategia correcta — confirmar en tests que no se produce `LazyInitializationException`.
+
+### R-007: Cobertura de datos seed por zona
+- El seed actual cubre `ZONE_A`, `ZONE_B`, `ZONE_C`, `ZONE_D` — suficiente para pruebas representativas.
+- Documentar en el README del módulo qué zonas cubre el seed y cómo agregar nuevos CPs.

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImpl.java
@@ -1,0 +1,25 @@
+package com.sofka.insurancequoter.core.zipcode.application.usecase;
+
+import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundException;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+
+/**
+ * Use case implementation — retrieves full zip code data.
+ * Registered as @Bean via ZipCodeConfig (no @Service annotation).
+ */
+public class GetZipCodeUseCaseImpl implements GetZipCodeUseCase {
+
+    private final ZipCodeRepository zipCodeRepository;
+
+    public GetZipCodeUseCaseImpl(ZipCodeRepository zipCodeRepository) {
+        this.zipCodeRepository = zipCodeRepository;
+    }
+
+    @Override
+    public ZipCode getByZipCode(String zipCode) {
+        return zipCodeRepository.findByZipCode(zipCode)
+                .orElseThrow(() -> new ZipCodeNotFoundException(zipCode));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImpl.java
@@ -1,0 +1,24 @@
+package com.sofka.insurancequoter.core.zipcode.application.usecase;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+
+/**
+ * Use case implementation — validates zip code existence.
+ * Always returns a result; never throws. Registered as @Bean via ZipCodeConfig.
+ */
+public class ValidateZipCodeUseCaseImpl implements ValidateZipCodeUseCase {
+
+    private final ZipCodeRepository zipCodeRepository;
+
+    public ValidateZipCodeUseCaseImpl(ZipCodeRepository zipCodeRepository) {
+        this.zipCodeRepository = zipCodeRepository;
+    }
+
+    @Override
+    public ZipCodeValidationResult validate(String zipCode) {
+        boolean exists = zipCodeRepository.findByZipCode(zipCode).isPresent();
+        return new ZipCodeValidationResult(exists, zipCode);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/exception/ZipCodeNotFoundException.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/exception/ZipCodeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sofka.insurancequoter.core.zipcode.domain.exception;
+
+/**
+ * Domain exception thrown when a requested zip code does not exist in the catalog.
+ */
+public class ZipCodeNotFoundException extends RuntimeException {
+
+    public ZipCodeNotFoundException(String zipCode) {
+        super("Zip code not found: " + zipCode);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/model/ZipCode.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/model/ZipCode.java
@@ -1,0 +1,18 @@
+package com.sofka.insurancequoter.core.zipcode.domain.model;
+
+import java.util.List;
+
+/**
+ * Domain model for a postal code (zip code).
+ * Pure Java record — no JPA or Spring annotations allowed here.
+ */
+public record ZipCode(
+        String zipCode,
+        String state,
+        String municipality,
+        String city,
+        List<String> neighborhoods,
+        String catastrophicZone,
+        String tevZone,
+        String fhmZone
+) {}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/model/ZipCodeValidationResult.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/model/ZipCodeValidationResult.java
@@ -1,0 +1,7 @@
+package com.sofka.insurancequoter.core.zipcode.domain.model;
+
+/**
+ * Domain model representing the result of validating a zip code existence.
+ * Pure Java record — no JPA or Spring annotations allowed here.
+ */
+public record ZipCodeValidationResult(boolean valid, String zipCode) {}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/in/GetZipCodeUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/in/GetZipCodeUseCase.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.core.zipcode.domain.port.in;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+
+/**
+ * Input port — retrieves full zip code data by zip code string.
+ * Throws ZipCodeNotFoundException when the zip code does not exist.
+ */
+public interface GetZipCodeUseCase {
+
+    ZipCode getByZipCode(String zipCode);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/in/ValidateZipCodeUseCase.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/in/ValidateZipCodeUseCase.java
@@ -1,0 +1,12 @@
+package com.sofka.insurancequoter.core.zipcode.domain.port.in;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+
+/**
+ * Input port — validates whether a zip code exists in the catalog.
+ * Always returns a result (never throws); valid=false when the zip code is not found.
+ */
+public interface ValidateZipCodeUseCase {
+
+    ZipCodeValidationResult validate(String zipCode);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/out/ZipCodeRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/domain/port/out/ZipCodeRepository.java
@@ -1,0 +1,14 @@
+package com.sofka.insurancequoter.core.zipcode.domain.port.out;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+
+import java.util.Optional;
+
+/**
+ * Output port — contract for zip code persistence access.
+ * Implemented by the infrastructure persistence adapter.
+ */
+public interface ZipCodeRepository {
+
+    Optional<ZipCode> findByZipCode(String zipCode);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/ZipCodeController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/ZipCodeController.java
@@ -1,0 +1,54 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundException;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ValidateZipCodeRequest;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeValidationResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.mapper.ZipCodeRestMapper;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.swaggerdocs.ZipCodeApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * REST controller for the Zip Codes resource.
+ * Delegates to use cases; no business logic here.
+ * Swagger annotations live in ZipCodeApi.
+ */
+@RestController
+@RequiredArgsConstructor
+public class ZipCodeController implements ZipCodeApi {
+
+    private final GetZipCodeUseCase getZipCodeUseCase;
+    private final ValidateZipCodeUseCase validateZipCodeUseCase;
+    private final ZipCodeRestMapper zipCodeRestMapper;
+
+    @Override
+    public ResponseEntity<ZipCodeResponse> getZipCode(String zipCode) {
+        ZipCodeResponse response = zipCodeRestMapper.toResponse(getZipCodeUseCase.getByZipCode(zipCode));
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<ZipCodeValidationResponse> validate(ValidateZipCodeRequest request) {
+        ZipCodeValidationResponse response = zipCodeRestMapper.toValidationResponse(
+                validateZipCodeUseCase.validate(request.zipCode())
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @ExceptionHandler(ZipCodeNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleZipCodeNotFound(ZipCodeNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of(
+                        "error", "Zip code not found",
+                        "code", "ZIP_CODE_NOT_FOUND"
+                ));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ValidateZipCodeRequest.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ValidateZipCodeRequest.java
@@ -1,0 +1,8 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * REST request DTO for POST /v1/zip-codes/validate.
+ */
+public record ValidateZipCodeRequest(@NotBlank String zipCode) {}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ZipCodeResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ZipCodeResponse.java
@@ -1,0 +1,19 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto;
+
+import java.util.List;
+
+/**
+ * REST response DTO for GET /v1/zip-codes/{zipCode}.
+ * valid is always true when returned from the GET endpoint (zip code was found).
+ */
+public record ZipCodeResponse(
+        String zipCode,
+        String state,
+        String municipality,
+        String city,
+        List<String> neighborhoods,
+        String catastrophicZone,
+        String tevZone,
+        String fhmZone,
+        boolean valid
+) {}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ZipCodeValidationResponse.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/dto/ZipCodeValidationResponse.java
@@ -1,0 +1,6 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto;
+
+/**
+ * REST response DTO for POST /v1/zip-codes/validate.
+ */
+public record ZipCodeValidationResponse(boolean valid, String zipCode) {}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/mapper/ZipCodeRestMapper.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/mapper/ZipCodeRestMapper.java
@@ -1,0 +1,40 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeValidationResponse;
+import org.springframework.stereotype.Component;
+
+/**
+ * REST mapper — converts domain models to REST DTOs.
+ * No business logic; pure field mapping.
+ */
+@Component
+public class ZipCodeRestMapper {
+
+    /**
+     * Maps a ZipCode domain model to ZipCodeResponse.
+     * valid is always true here — the zip code was found by the use case.
+     */
+    public ZipCodeResponse toResponse(ZipCode zipCode) {
+        return new ZipCodeResponse(
+                zipCode.zipCode(),
+                zipCode.state(),
+                zipCode.municipality(),
+                zipCode.city(),
+                zipCode.neighborhoods(),
+                zipCode.catastrophicZone(),
+                zipCode.tevZone(),
+                zipCode.fhmZone(),
+                true
+        );
+    }
+
+    /**
+     * Maps a ZipCodeValidationResult domain model to ZipCodeValidationResponse.
+     */
+    public ZipCodeValidationResponse toValidationResponse(ZipCodeValidationResult result) {
+        return new ZipCodeValidationResponse(result.valid(), result.zipCode());
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/swaggerdocs/ZipCodeApi.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/swaggerdocs/ZipCodeApi.java
@@ -1,0 +1,42 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.swaggerdocs;
+
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ValidateZipCodeRequest;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeValidationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Swagger / OpenAPI contract for the Zip Codes resource.
+ * All @Tag, @Operation and @ApiResponse annotations live here — never in the controller.
+ */
+@Tag(name = "Zip Codes", description = "Consulta y validación de códigos postales")
+@RequestMapping("/v1/zip-codes")
+public interface ZipCodeApi {
+
+    @Operation(summary = "Obtener datos completos de un código postal")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Código postal encontrado"),
+            @ApiResponse(responseCode = "404", description = "Código postal no encontrado"),
+            @ApiResponse(responseCode = "400", description = "Formato de código postal inválido")
+    })
+    @GetMapping("/{zipCode}")
+    ResponseEntity<ZipCodeResponse> getZipCode(@PathVariable String zipCode);
+
+    @Operation(summary = "Validar existencia de un código postal")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Resultado de validación"),
+            @ApiResponse(responseCode = "400", description = "Request inválido — zipCode requerido")
+    })
+    @PostMapping("/validate")
+    ResponseEntity<ZipCodeValidationResponse> validate(@Valid @RequestBody ValidateZipCodeRequest request);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodeJpaRepository.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodeJpaRepository.java
@@ -1,0 +1,18 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity.ZipCodeJpa;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+/**
+ * Spring Data JPA repository for zip codes.
+ * Uses JOIN FETCH to load neighborhoods in a single query and avoid N+1.
+ */
+public interface ZipCodeJpaRepository extends JpaRepository<ZipCodeJpa, String> {
+
+    @Query("SELECT z FROM ZipCodeJpa z LEFT JOIN FETCH z.neighborhoods WHERE z.zipCode = :zipCode")
+    Optional<ZipCodeJpa> findByZipCodeWithNeighborhoods(@Param("zipCode") String zipCode);
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodePersistenceAdapter.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodePersistenceAdapter.java
@@ -1,0 +1,47 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity.ZipCodeJpa;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity.ZipCodeNeighborhoodJpa;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Persistence adapter — implements ZipCodeRepository output port using Spring Data JPA.
+ * Maps ZipCodeJpa → ZipCode domain model before returning to the application layer.
+ */
+@Component
+@RequiredArgsConstructor
+public class ZipCodePersistenceAdapter implements ZipCodeRepository {
+
+    private final ZipCodeJpaRepository zipCodeJpaRepository;
+
+    @Override
+    public Optional<ZipCode> findByZipCode(String zipCode) {
+        return zipCodeJpaRepository.findByZipCodeWithNeighborhoods(zipCode)
+                .map(this::toDomain);
+    }
+
+    private ZipCode toDomain(ZipCodeJpa jpa) {
+        List<String> neighborhoods = jpa.getNeighborhoods() == null
+                ? List.of()
+                : jpa.getNeighborhoods().stream()
+                        .map(ZipCodeNeighborhoodJpa::getNeighborhood)
+                        .toList();
+
+        return new ZipCode(
+                jpa.getZipCode(),
+                jpa.getState(),
+                jpa.getMunicipality(),
+                jpa.getCity(),
+                neighborhoods,
+                jpa.getCatastrophicZone(),
+                jpa.getTevZone(),
+                jpa.getFhmZone()
+        );
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/entity/ZipCodeJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/entity/ZipCodeJpa.java
@@ -1,0 +1,53 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * JPA entity mapping the zip_codes table.
+ * Never exposed outside the persistence adapter — map to domain model before returning.
+ */
+@Entity
+@Table(name = "zip_codes")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ZipCodeJpa {
+
+    @Id
+    @Column(name = "zip_code", nullable = false, length = 10)
+    private String zipCode;
+
+    @Column(name = "state", nullable = false, length = 100)
+    private String state;
+
+    @Column(name = "municipality", nullable = false, length = 100)
+    private String municipality;
+
+    @Column(name = "city", nullable = false, length = 100)
+    private String city;
+
+    @Column(name = "catastrophic_zone", nullable = false, length = 20)
+    private String catastrophicZone;
+
+    @Column(name = "tev_zone", nullable = false, length = 20)
+    private String tevZone;
+
+    @Column(name = "fhm_zone", nullable = false, length = 20)
+    private String fhmZone;
+
+    @OneToMany(mappedBy = "zipCode", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ZipCodeNeighborhoodJpa> neighborhoods;
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/entity/ZipCodeNeighborhoodJpa.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/entity/ZipCodeNeighborhoodJpa.java
@@ -1,0 +1,39 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JPA entity mapping the zip_code_neighborhoods table.
+ * Never exposed outside the persistence adapter.
+ */
+@Entity
+@Table(name = "zip_code_neighborhoods")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ZipCodeNeighborhoodJpa {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "zip_code", nullable = false)
+    private ZipCodeJpa zipCode;
+
+    @Column(name = "neighborhood", nullable = false, length = 150)
+    private String neighborhood;
+}

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/config/ZipCodeConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/config/ZipCodeConfig.java
@@ -1,0 +1,28 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.config;
+
+import com.sofka.insurancequoter.core.zipcode.application.usecase.GetZipCodeUseCaseImpl;
+import com.sofka.insurancequoter.core.zipcode.application.usecase.ValidateZipCodeUseCaseImpl;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for the zipcode bounded context.
+ * Wires use case implementations without placing Spring annotations in the application layer.
+ * ZipCodePersistenceAdapter is @Component and satisfies ZipCodeRepository automatically.
+ */
+@Configuration
+public class ZipCodeConfig {
+
+    @Bean
+    public GetZipCodeUseCase getZipCodeUseCase(ZipCodeRepository zipCodeRepository) {
+        return new GetZipCodeUseCaseImpl(zipCodeRepository);
+    }
+
+    @Bean
+    public ValidateZipCodeUseCase validateZipCodeUseCase(ZipCodeRepository zipCodeRepository) {
+        return new ValidateZipCodeUseCaseImpl(zipCodeRepository);
+    }
+}

--- a/src/main/resources/db/migration/V2__create_zip_codes.sql
+++ b/src/main/resources/db/migration/V2__create_zip_codes.sql
@@ -1,0 +1,21 @@
+-- DDL for zip codes catalog.
+-- zip_codes is a read-only lookup table; no write endpoints exist at runtime.
+CREATE TABLE zip_codes (
+    zip_code          VARCHAR(10)  PRIMARY KEY,
+    state             VARCHAR(100) NOT NULL,
+    municipality      VARCHAR(100) NOT NULL,
+    city              VARCHAR(100) NOT NULL,
+    catastrophic_zone VARCHAR(20)  NOT NULL,
+    tev_zone          VARCHAR(20)  NOT NULL,
+    fhm_zone          VARCHAR(20)  NOT NULL
+);
+
+-- Neighborhoods are stored separately to support 0..N per zip code.
+CREATE TABLE zip_code_neighborhoods (
+    id           BIGSERIAL    PRIMARY KEY,
+    zip_code     VARCHAR(10)  NOT NULL REFERENCES zip_codes(zip_code),
+    neighborhood VARCHAR(150) NOT NULL
+);
+
+-- Index to avoid full-table scan when loading neighborhoods for a given zip code.
+CREATE INDEX idx_zip_code_neighborhoods_zip_code ON zip_code_neighborhoods(zip_code);

--- a/src/main/resources/db/migration/V3__seed_zip_codes.sql
+++ b/src/main/resources/db/migration/V3__seed_zip_codes.sql
@@ -1,0 +1,21 @@
+-- Seed data for zip_codes catalog.
+-- At least 5 representative postal codes from different states and zones.
+INSERT INTO zip_codes (zip_code, state, municipality, city, catastrophic_zone, tev_zone, fhm_zone) VALUES
+    ('06600', 'Ciudad de México', 'Cuauhtémoc',      'Ciudad de México', 'ZONE_A', 'TEV-1', 'FHM-2'),
+    ('44100', 'Jalisco',          'Guadalajara',      'Guadalajara',      'ZONE_B', 'TEV-2', 'FHM-1'),
+    ('64000', 'Nuevo León',       'Monterrey',        'Monterrey',        'ZONE_C', 'TEV-3', 'FHM-3'),
+    ('72000', 'Puebla',           'Puebla',           'Puebla',           'ZONE_B', 'TEV-2', 'FHM-2'),
+    ('20000', 'Aguascalientes',   'Aguascalientes',   'Aguascalientes',   'ZONE_D', 'TEV-4', 'FHM-1');
+
+-- Neighborhoods for CDMX zip code
+INSERT INTO zip_code_neighborhoods (zip_code, neighborhood) VALUES
+    ('06600', 'Juárez'),
+    ('06600', 'Tabacalera');
+
+-- Neighborhoods for Guadalajara zip code
+INSERT INTO zip_code_neighborhoods (zip_code, neighborhood) VALUES
+    ('44100', 'Centro');
+
+-- Neighborhoods for Monterrey zip code
+INSERT INTO zip_code_neighborhoods (zip_code, neighborhood) VALUES
+    ('64000', 'Centro');

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImplTest.java
@@ -1,0 +1,61 @@
+package com.sofka.insurancequoter.core.zipcode.application.usecase;
+
+import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundException;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetZipCodeUseCaseImplTest {
+
+    @Mock
+    private ZipCodeRepository zipCodeRepository;
+
+    private GetZipCodeUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetZipCodeUseCaseImpl(zipCodeRepository);
+    }
+
+    @Test
+    void getByZipCode_whenZipCodeExists_returnsZipCode() {
+        // GIVEN
+        ZipCode expected = new ZipCode(
+                "06600", "Ciudad de México", "Cuauhtémoc", "Ciudad de México",
+                List.of("Juárez", "Tabacalera"), "ZONE_A", "TEV-1", "FHM-2"
+        );
+        when(zipCodeRepository.findByZipCode("06600")).thenReturn(Optional.of(expected));
+
+        // WHEN
+        ZipCode result = useCase.getByZipCode("06600");
+
+        // THEN
+        assertThat(result).isEqualTo(expected);
+        verify(zipCodeRepository, times(1)).findByZipCode("06600");
+    }
+
+    @Test
+    void getByZipCode_whenZipCodeDoesNotExist_throwsZipCodeNotFoundException() {
+        // GIVEN
+        when(zipCodeRepository.findByZipCode("99999")).thenReturn(Optional.empty());
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> useCase.getByZipCode("99999"))
+                .isInstanceOf(ZipCodeNotFoundException.class)
+                .hasMessageContaining("99999");
+
+        verify(zipCodeRepository, times(1)).findByZipCode("99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImplTest.java
@@ -1,0 +1,62 @@
+package com.sofka.insurancequoter.core.zipcode.application.usecase;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ValidateZipCodeUseCaseImplTest {
+
+    @Mock
+    private ZipCodeRepository zipCodeRepository;
+
+    private ValidateZipCodeUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidateZipCodeUseCaseImpl(zipCodeRepository);
+    }
+
+    @Test
+    void validate_whenZipCodeExists_returnsValidTrue() {
+        // GIVEN
+        ZipCode zipCode = new ZipCode(
+                "06600", "Ciudad de México", "Cuauhtémoc", "Ciudad de México",
+                List.of("Juárez"), "ZONE_A", "TEV-1", "FHM-2"
+        );
+        when(zipCodeRepository.findByZipCode("06600")).thenReturn(Optional.of(zipCode));
+
+        // WHEN
+        ZipCodeValidationResult result = useCase.validate("06600");
+
+        // THEN
+        assertThat(result.valid()).isTrue();
+        assertThat(result.zipCode()).isEqualTo("06600");
+        verify(zipCodeRepository, times(1)).findByZipCode("06600");
+    }
+
+    @Test
+    void validate_whenZipCodeDoesNotExist_returnsValidFalse() {
+        // GIVEN
+        when(zipCodeRepository.findByZipCode("99999")).thenReturn(Optional.empty());
+
+        // WHEN
+        ZipCodeValidationResult result = useCase.validate("99999");
+
+        // THEN
+        assertThat(result.valid()).isFalse();
+        assertThat(result.zipCode()).isEqualTo("99999");
+        verify(zipCodeRepository, times(1)).findByZipCode("99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/ZipCodeIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/ZipCodeIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class ZipCodeIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configurePostgres(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        // Flyway runs the migrations; Hibernate must not attempt DDL
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    @LocalServerPort
+    int port;
+
+    private RestClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = RestClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .build();
+    }
+
+    // ---- GET /v1/zip-codes/{zipCode} ----
+
+    @Test
+    void getZipCode_whenExists_returns200WithFullData() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = client.get()
+                .uri("/v1/zip-codes/06600")
+                .retrieve()
+                .body(Map.class);
+
+        assertThat(body).isNotNull();
+        assertThat(body.get("zipCode")).isEqualTo("06600");
+        assertThat(body.get("state")).isNotNull();
+        assertThat(body.get("municipality")).isNotNull();
+        assertThat(body.get("city")).isNotNull();
+        assertThat(body.get("valid")).isEqualTo(true);
+
+        @SuppressWarnings("unchecked")
+        List<String> neighborhoods = (List<String>) body.get("neighborhoods");
+        assertThat(neighborhoods).contains("Juárez");
+    }
+
+    @Test
+    void getZipCode_whenNotFound_returns404() {
+        assertThatThrownBy(() ->
+                client.get()
+                        .uri("/v1/zip-codes/99999")
+                        .retrieve()
+                        .body(Map.class)
+        ).isInstanceOfSatisfying(HttpClientErrorException.class, ex -> {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(ex.getResponseBodyAsString()).contains("ZIP_CODE_NOT_FOUND");
+        });
+    }
+
+    // ---- POST /v1/zip-codes/validate ----
+
+    @Test
+    void validate_whenZipCodeExists_returns200WithValidTrue() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = client.post()
+                .uri("/v1/zip-codes/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("zipCode", "06600"))
+                .retrieve()
+                .body(Map.class);
+
+        assertThat(body).isNotNull();
+        assertThat(body.get("valid")).isEqualTo(true);
+        assertThat(body.get("zipCode")).isEqualTo("06600");
+    }
+
+    @Test
+    void validate_whenZipCodeDoesNotExist_returns200WithValidFalse() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = client.post()
+                .uri("/v1/zip-codes/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("zipCode", "99999"))
+                .retrieve()
+                .body(Map.class);
+
+        assertThat(body).isNotNull();
+        assertThat(body.get("valid")).isEqualTo(false);
+        assertThat(body.get("zipCode")).isEqualTo("99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/ZipCodeControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/ZipCodeControllerTest.java
@@ -1,0 +1,120 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest;
+
+import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundException;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ValidateZipCodeRequest;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeValidationResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.mapper.ZipCodeRestMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ZipCodeControllerTest {
+
+    @Mock
+    private GetZipCodeUseCase getZipCodeUseCase;
+
+    @Mock
+    private ValidateZipCodeUseCase validateZipCodeUseCase;
+
+    @Mock
+    private ZipCodeRestMapper zipCodeRestMapper;
+
+    @InjectMocks
+    private ZipCodeController controller;
+
+    // ---- GET /v1/zip-codes/{zipCode} ----
+
+    @Test
+    void getZipCode_whenExists_returns200WithBody() {
+        // GIVEN
+        ZipCode zipCode = new ZipCode("06600", "Ciudad de México", "Cuauhtémoc", "Ciudad de México",
+                List.of("Juárez", "Tabacalera"), "ZONE_A", "TEV-1", "FHM-2");
+        ZipCodeResponse response = new ZipCodeResponse("06600", "Ciudad de México", "Cuauhtémoc",
+                "Ciudad de México", List.of("Juárez", "Tabacalera"), "ZONE_A", "TEV-1", "FHM-2", true);
+
+        when(getZipCodeUseCase.getByZipCode("06600")).thenReturn(zipCode);
+        when(zipCodeRestMapper.toResponse(zipCode)).thenReturn(response);
+
+        // WHEN
+        ResponseEntity<ZipCodeResponse> result = controller.getZipCode("06600");
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().zipCode()).isEqualTo("06600");
+        assertThat(result.getBody().valid()).isTrue();
+    }
+
+    @Test
+    void handleZipCodeNotFound_returns404WithStandardErrorBody() {
+        // GIVEN — the exception handler is tested directly (Mockito-only, no Spring dispatcher)
+        ZipCodeNotFoundException ex = new ZipCodeNotFoundException("99999");
+
+        // WHEN
+        ResponseEntity<Map<String, String>> result = controller.handleZipCodeNotFound(ex);
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().get("error")).isEqualTo("Zip code not found");
+        assertThat(result.getBody().get("code")).isEqualTo("ZIP_CODE_NOT_FOUND");
+    }
+
+    // ---- POST /v1/zip-codes/validate ----
+
+    @Test
+    void validate_whenZipCodeIsValid_returns200WithValidTrue() {
+        // GIVEN
+        ValidateZipCodeRequest request = new ValidateZipCodeRequest("06600");
+        ZipCodeValidationResult domainResult = new ZipCodeValidationResult(true, "06600");
+        ZipCodeValidationResponse response = new ZipCodeValidationResponse(true, "06600");
+
+        when(validateZipCodeUseCase.validate("06600")).thenReturn(domainResult);
+        when(zipCodeRestMapper.toValidationResponse(domainResult)).thenReturn(response);
+
+        // WHEN
+        ResponseEntity<ZipCodeValidationResponse> result = controller.validate(request);
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().valid()).isTrue();
+        assertThat(result.getBody().zipCode()).isEqualTo("06600");
+    }
+
+    @Test
+    void validate_whenZipCodeIsInvalid_returns200WithValidFalse() {
+        // GIVEN
+        ValidateZipCodeRequest request = new ValidateZipCodeRequest("99999");
+        ZipCodeValidationResult domainResult = new ZipCodeValidationResult(false, "99999");
+        ZipCodeValidationResponse response = new ZipCodeValidationResponse(false, "99999");
+
+        when(validateZipCodeUseCase.validate("99999")).thenReturn(domainResult);
+        when(zipCodeRestMapper.toValidationResponse(domainResult)).thenReturn(response);
+
+        // WHEN
+        ResponseEntity<ZipCodeValidationResponse> result = controller.validate(request);
+
+        // THEN
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().valid()).isFalse();
+        assertThat(result.getBody().zipCode()).isEqualTo("99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/mapper/ZipCodeRestMapperTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/in/rest/mapper/ZipCodeRestMapperTest.java
@@ -1,0 +1,71 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.mapper;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeResponse;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.in.rest.dto.ZipCodeValidationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ZipCodeRestMapperTest {
+
+    private ZipCodeRestMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ZipCodeRestMapper();
+    }
+
+    @Test
+    void toResponse_mapsAllFieldsAndSetsValidTrue() {
+        // GIVEN
+        ZipCode zipCode = new ZipCode(
+                "06600", "Ciudad de México", "Cuauhtémoc", "Ciudad de México",
+                List.of("Juárez", "Tabacalera"), "ZONE_A", "TEV-1", "FHM-2"
+        );
+
+        // WHEN
+        ZipCodeResponse response = mapper.toResponse(zipCode);
+
+        // THEN
+        assertThat(response.zipCode()).isEqualTo("06600");
+        assertThat(response.state()).isEqualTo("Ciudad de México");
+        assertThat(response.municipality()).isEqualTo("Cuauhtémoc");
+        assertThat(response.city()).isEqualTo("Ciudad de México");
+        assertThat(response.neighborhoods()).containsExactly("Juárez", "Tabacalera");
+        assertThat(response.catastrophicZone()).isEqualTo("ZONE_A");
+        assertThat(response.tevZone()).isEqualTo("TEV-1");
+        assertThat(response.fhmZone()).isEqualTo("FHM-2");
+        assertThat(response.valid()).isTrue();
+    }
+
+    @Test
+    void toValidationResponse_whenValid_mapsCorrectly() {
+        // GIVEN
+        ZipCodeValidationResult result = new ZipCodeValidationResult(true, "06600");
+
+        // WHEN
+        ZipCodeValidationResponse response = mapper.toValidationResponse(result);
+
+        // THEN
+        assertThat(response.valid()).isTrue();
+        assertThat(response.zipCode()).isEqualTo("06600");
+    }
+
+    @Test
+    void toValidationResponse_whenInvalid_mapsCorrectly() {
+        // GIVEN
+        ZipCodeValidationResult result = new ZipCodeValidationResult(false, "99999");
+
+        // WHEN
+        ZipCodeValidationResponse response = mapper.toValidationResponse(result);
+
+        // THEN
+        assertThat(response.valid()).isFalse();
+        assertThat(response.zipCode()).isEqualTo("99999");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodePersistenceAdapterTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/infrastructure/adapter/out/persistence/ZipCodePersistenceAdapterTest.java
@@ -1,0 +1,105 @@
+package com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence;
+
+import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity.ZipCodeJpa;
+import com.sofka.insurancequoter.core.zipcode.infrastructure.adapter.out.persistence.entity.ZipCodeNeighborhoodJpa;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ZipCodePersistenceAdapterTest {
+
+    @Mock
+    private ZipCodeJpaRepository zipCodeJpaRepository;
+
+    private ZipCodePersistenceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ZipCodePersistenceAdapter(zipCodeJpaRepository);
+    }
+
+    @Test
+    void findByZipCode_whenFoundWithNeighborhoods_mapsCorrectly() {
+        // GIVEN
+        ZipCodeJpa jpa = buildJpaWithNeighborhoods("06600",
+                List.of("Juárez", "Tabacalera"));
+        when(zipCodeJpaRepository.findByZipCodeWithNeighborhoods("06600"))
+                .thenReturn(Optional.of(jpa));
+
+        // WHEN
+        Optional<ZipCode> result = adapter.findByZipCode("06600");
+
+        // THEN
+        assertThat(result).isPresent();
+        ZipCode zipCode = result.get();
+        assertThat(zipCode.zipCode()).isEqualTo("06600");
+        assertThat(zipCode.state()).isEqualTo("Ciudad de México");
+        assertThat(zipCode.municipality()).isEqualTo("Cuauhtémoc");
+        assertThat(zipCode.city()).isEqualTo("Ciudad de México");
+        assertThat(zipCode.neighborhoods()).containsExactlyInAnyOrder("Juárez", "Tabacalera");
+        assertThat(zipCode.catastrophicZone()).isEqualTo("ZONE_A");
+        assertThat(zipCode.tevZone()).isEqualTo("TEV-1");
+        assertThat(zipCode.fhmZone()).isEqualTo("FHM-2");
+    }
+
+    @Test
+    void findByZipCode_whenFoundWithoutNeighborhoods_returnsEmptyNeighborhoodsList() {
+        // GIVEN
+        ZipCodeJpa jpa = buildJpaWithNeighborhoods("44100", List.of());
+        when(zipCodeJpaRepository.findByZipCodeWithNeighborhoods("44100"))
+                .thenReturn(Optional.of(jpa));
+
+        // WHEN
+        Optional<ZipCode> result = adapter.findByZipCode("44100");
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().neighborhoods()).isEmpty();
+    }
+
+    @Test
+    void findByZipCode_whenNotFound_returnsEmpty() {
+        // GIVEN
+        when(zipCodeJpaRepository.findByZipCodeWithNeighborhoods("99999"))
+                .thenReturn(Optional.empty());
+
+        // WHEN
+        Optional<ZipCode> result = adapter.findByZipCode("99999");
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    // ---- helpers ----
+
+    private ZipCodeJpa buildJpaWithNeighborhoods(String zipCode, List<String> neighborhoodNames) {
+        ZipCodeJpa jpa = ZipCodeJpa.builder()
+                .zipCode(zipCode)
+                .state("Ciudad de México")
+                .municipality("Cuauhtémoc")
+                .city("Ciudad de México")
+                .catastrophicZone("ZONE_A")
+                .tevZone("TEV-1")
+                .fhmZone("FHM-2")
+                .build();
+
+        List<ZipCodeNeighborhoodJpa> neighborhoods = neighborhoodNames.stream()
+                .map(name -> ZipCodeNeighborhoodJpa.builder()
+                        .zipCode(jpa)
+                        .neighborhood(name)
+                        .build())
+                .toList();
+        jpa.setNeighborhoods(neighborhoods);
+        return jpa;
+    }
+}


### PR DESCRIPTION
## Descripción

Implementa consulta y validación de códigos postales (`GET /v1/zip-codes/{zipCode}` y `POST /v1/zip-codes/validate`) en `Insurance-Quoter-Core`.

Los datos se persisten en PostgreSQL con dos tablas (`zip_codes` y `zip_code_neighborhoods`) cargadas mediante migraciones Flyway.

## Cambios

### Base de datos (Flyway)
- `V2__create_zip_codes.sql` — DDL de `zip_codes` y `zip_code_neighborhoods` con índice en FK
- `V3__seed_zip_codes.sql` — 5 CPs seed representativos de distintos estados y zonas catastróficas

### Producción
- `ZipCode`, `ZipCodeValidationResult` — domain records sin anotaciones
- `ZipCodeNotFoundException` — excepción de dominio
- `ZipCodeRepository`, `GetZipCodeUseCase`, `ValidateZipCodeUseCase` — ports
- `GetZipCodeUseCaseImpl`, `ValidateZipCodeUseCaseImpl` — use cases
- `ZipCodeJpa`, `ZipCodeNeighborhoodJpa` — entidades JPA
- `ZipCodeJpaRepository` — Spring Data con `JOIN FETCH` para evitar N+1
- `ZipCodePersistenceAdapter` — implementa output port
- `ZipCodeController` / `ZipCodeApi` — endpoints REST con Swagger separado
- `ZipCodeRestMapper`, `ZipCodeResponse`, `ValidateZipCodeRequest`, `ZipCodeValidationResponse` — mapeo y DTOs
- `ZipCodeConfig` — wiring de beans

### Tests
- `GetZipCodeUseCaseImplTest` — unitario Mockito
- `ValidateZipCodeUseCaseImplTest` — unitario Mockito
- `ZipCodePersistenceAdapterTest` — unitario (con/sin colonias, CP no encontrado)
- `ZipCodeRestMapperTest` — unitario
- `ZipCodeControllerTest` — unitario (GET 200, GET 404, POST valid/invalid)
- `ZipCodeIntegrationTest` — `@SpringBootTest` + Testcontainers + PostgreSQL real

### QA
- Matriz de riesgos: `docs/output/qa/zip-codes-risks.md` (3 ALTO, 4 MEDIO, 1 BAJO)
- Escenarios Gherkin: `docs/output/qa/zip-codes-gherkin.md` (13 escenarios)
- Validación manual: 4 escenarios validados con curl ✅

## Issues cerrados

Closes #89, #90, #91, #92, #93, #94, #95, #96, #97, #98, #99, #100, #101, #102, #103, #104, #105, #106, #107, #108, #109, #110, #111, #112, #113, #114, #115, #116

## Checklist

- [x] `./gradlew test` — BUILD SUCCESSFUL
- [x] GET /v1/zip-codes/06600 → 200 con zonas y colonias correctas
- [x] GET /v1/zip-codes/99999 → 404 ZIP_CODE_NOT_FOUND
- [x] POST /v1/zip-codes/validate {06600} → 200 valid:true
- [x] POST /v1/zip-codes/validate {99999} → 200 valid:false
- [x] Sin `@Autowired`, Swagger solo en `swaggerdocs/`
- [x] `JOIN FETCH` en neighborhoods para evitar N+1
- [x] Todos los issues del feature cerrados