### PR TITLE
release: v1.1.0 — Observabilidad completa (3 pilares)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,6 @@
   "permissions": {
     "defaultMode": "bypassPermissions",
     "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)",
       "Read(./backend/firebase_credentials.json)",
       "Read(./secrets/**)",
       "Bash(git reset --hard *)",

--- a/.claude/specs/observability-core.spec.md
+++ b/.claude/specs/observability-core.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-009
-status: DRAFT
+status: APPROVED
 feature: observability-core
 created: 2026-04-27
 updated: 2026-04-27

--- a/.claude/specs/observability-core.spec.md
+++ b/.claude/specs/observability-core.spec.md
@@ -1,0 +1,552 @@
+---
+id: SPEC-009
+status: DRAFT
+feature: observability-core
+created: 2026-04-27
+updated: 2026-04-27
+author: spec-generator
+version: "1.0"
+related-specs: []
+---
+
+# SPEC-009 — Observabilidad completa (3 pilares) para Insurance-Quoter-Core
+
+## 1. REQUERIMIENTOS
+
+### Historia de usuario
+
+**HU-01 — Logs estructurados con correlación de trazas**
+> Como operador de plataforma, quiero que cada línea de log del Core incluya `traceId` y `spanId` en formato JSON estructurado, para poder correlacionar logs con trazas distribuidas en Jaeger.
+
+**HU-02 — Métricas de negocio y sistema**
+> Como SRE, quiero métricas de JVM, HTTP, pool de conexiones y operaciones de negocio expuestas en `/actuator/prometheus`, para alertar sobre degradación del servicio y auditar el volumen de operaciones.
+
+**HU-03 — Trazas distribuidas continuas**
+> Como desarrollador, quiero que el Core continúe la traza iniciada por Insurance-Quoter-Back (header `traceparent`) sin crear un nuevo root trace, y que cada use case genere su propio span mediante `@Observed`, para tener visibilidad end-to-end de cada request.
+
+---
+
+### Criterios de aceptación (Gherkin)
+
+#### HU-01 — Logs estructurados
+
+```gherkin
+Escenario: Log de request HTTP incluye traceId y spanId
+  Dado que Insurance-Quoter-Back llama a GET /v1/folios con header traceparent
+  Cuando el Core procesa la solicitud
+  Entonces cada línea de log de esa request contiene traceId no vacío
+  Y cada línea de log contiene spanId no vacío
+  Y el formato del log es JSON estructurado (Logstash/ECS)
+
+Escenario: Log sin traceparent genera su propio traceId
+  Dado que un cliente llama directamente al Core sin header traceparent
+  Cuando el Core procesa la solicitud
+  Entonces el log contiene un traceId generado localmente
+  Y spanId no es vacío
+```
+
+#### HU-02 — Métricas de negocio
+
+```gherkin
+Escenario: Contador de folios generados
+  Dado que /actuator/prometheus está habilitado
+  Cuando se realiza un GET /v1/folios exitoso
+  Entonces la métrica folios_generated_total se incrementa en 1
+
+Escenario: Contador y timer de consultas de tarifas
+  Dado que /actuator/prometheus está habilitado
+  Cuando se realiza un GET /v1/tariffs con parámetro fireKey="RC001"
+  Entonces tariff_lookups_total{fireKey="RC001"} se incrementa en 1
+  Y tariff_lookup_duration_seconds{fireKey="RC001"} registra la duración
+
+Escenario: Contador de búsquedas de código postal — encontrado
+  Dado que /actuator/prometheus está habilitado
+  Cuando se realiza un GET /v1/zip-codes/06600 y el código existe
+  Entonces zipcode_lookups_total{found="true"} se incrementa en 1
+
+Escenario: Contador de búsquedas de código postal — no encontrado
+  Dado que /actuator/prometheus está habilitado
+  Cuando se realiza un GET /v1/zip-codes/99999 y el código no existe
+  Entonces zipcode_lookups_total{found="false"} se incrementa en 1
+
+Escenario: Contadores de agentes y suscriptores
+  Dado que /actuator/prometheus está habilitado
+  Cuando se realiza un GET /v1/agents exitoso
+  Entonces agent_queries_total se incrementa en 1
+  Cuando se realiza un GET /v1/subscribers exitoso
+  Entonces subscriber_queries_total se incrementa en 1
+
+Escenario: Contador de errores de catálogo
+  Dado que /actuator/prometheus está habilitado
+  Cuando una operación de catálogo lanza una excepción de tipo "DATABASE_ERROR"
+  Entonces catalog_errors_total{errorType="DATABASE_ERROR"} se incrementa en 1
+
+Escenario: Métricas JVM y HTTP disponibles
+  Dado que actuator está configurado
+  Cuando se consulta /actuator/prometheus
+  Entonces la respuesta contiene jvm_memory_used_bytes
+  Y contiene http_server_requests_seconds_count
+  Y contiene hikaricp_connections_active
+```
+
+#### HU-03 — Trazas distribuidas
+
+```gherkin
+Escenario: Core continúa traza de Back — no crea root
+  Dado que Insurance-Quoter-Back envía request con header traceparent="00-<traceId>-<spanId>-01"
+  Cuando el Core recibe la request
+  Entonces el span creado por el Core tiene el mismo traceId de Back
+  Y el span padre es el spanId enviado por Back
+  Y Jaeger muestra ambos servicios bajo un mismo trace
+
+Escenario: Use case genera span propio vía @Observed
+  Dado que el Core recibe un request para GET /v1/folios
+  Cuando GenerateFolioUseCaseImpl ejecuta
+  Entonces Jaeger muestra un span con nombre "GenerateFolioUseCaseImpl#execute" (o similar)
+  Y el span es hijo del span HTTP server
+
+Escenario: Spans JDBC registrados automáticamente
+  Dado que un use case ejecuta una query a PostgreSQL
+  Cuando el Core procesa la solicitud
+  Entonces Jaeger muestra un span db.postgresql con la query ejecutada
+```
+
+---
+
+### Reglas de negocio
+
+1. **Propagación de traza obligatoria**: El Core NO debe crear un root trace si el header `traceparent` (W3C Trace Context) está presente. Spring Boot 4 + `micrometer-tracing-bridge-otel` lo resuelve automáticamente; no se requiere código adicional.
+2. **`@Observed` solo en use case implementations**: No anotar interfaces, controllers, ni adapters de persistencia.
+3. **Tags de métricas bajos cardinalidad**: Los tags `fireKey` y `errorType` deben provenir de enumeraciones o valores controlados, nunca de input libre del usuario.
+4. **Un solo Jaeger para ambos servicios**: El Core apunta a `localhost:4317` (OTLP gRPC) — el mismo Jaeger que usa Insurance-Quoter-Back. No se despliega un Jaeger separado.
+5. **Prometheus scrape independiente**: El Prometheus del Core tiene `job_name: insurance-quoter-core` apuntando a `localhost:8081/actuator/prometheus`.
+6. **Endpoints actuator mínimos expuestos**: `health`, `info`, `prometheus`, `metrics`. El endpoint `beans` y `env` NO se exponen en producción.
+
+---
+
+## 2. DISEÑO
+
+### 2.1 Dependencias — `build.gradle.kts`
+
+Agregar al bloque `dependencies`:
+
+```kotlin
+// Observabilidad
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+implementation("io.micrometer:micrometer-registry-prometheus")
+implementation("io.micrometer:micrometer-tracing-bridge-otel")
+implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+runtimeOnly("io.micrometer:micrometer-observation")
+```
+
+> **Nota**: Con Spring Boot 4 BOM, no se especifican versiones explícitas para micrometer ni opentelemetry — el BOM los gestiona.
+
+---
+
+### 2.2 Configuración — `application.properties`
+
+```properties
+# ── Actuator ──────────────────────────────────────────────────────────────
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
+management.endpoint.health.show-details=always
+management.metrics.tags.application=${spring.application.name}
+management.metrics.tags.environment=${spring.profiles.active:local}
+
+# ── Tracing ───────────────────────────────────────────────────────────────
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=http://localhost:4317
+management.otlp.tracing.compression=gzip
+
+# ── OTLP Metrics (opcional, si se quiere enviar métricas también a OTel collector)
+# management.otlp.metrics.export.url=http://localhost:4318/v1/metrics
+
+# ── Logging con traceId/spanId ─────────────────────────────────────────────
+logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
+```
+
+---
+
+### 2.3 Logs estructurados — `logback-spring.xml`
+
+Archivo: `src/main/resources/logback-spring.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <customFields>{"service":"${appName}"}</customFields>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+  <logger name="com.sofka.insurancequoter" level="DEBUG"/>
+</configuration>
+```
+
+**Dependencia adicional para Logstash encoder:**
+```kotlin
+implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+```
+
+> El encoder `LogstashEncoder` serializa cada log como JSON e inyecta automáticamente `traceId` y `spanId` desde el MDC cuando `micrometer-tracing` está en classpath.
+
+---
+
+### 2.4 Configuración de observabilidad — `ObservabilityConfig.java`
+
+Ubicación: `infrastructure/config/ObservabilityConfig.java`
+
+```java
+@Configuration
+@EnableObservability  // habilita @Observed AOP
+public class ObservabilityConfig {
+
+    @Bean
+    ObservedAspect observedAspect(ObservationRegistry registry) {
+        return new ObservedAspect(registry);
+    }
+}
+```
+
+> `@EnableObservability` es la anotación de Spring Boot 4 que activa el soporte AOP para `@Observed`. Sin esto, la anotación no genera spans.
+
+**Dependencia AOP requerida:**
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-aop")
+```
+
+---
+
+### 2.5 `@Observed` en use cases
+
+Agregar `@Observed` en cada use case implementation. La anotación va sobre la **clase** para interceptar todos sus métodos públicos.
+
+| Use case | Bounded context | Span name sugerido |
+|---|---|---|
+| `GenerateFolioUseCaseImpl` | folio | `folio.generate` |
+| `GetAgentsUseCaseImpl` | agent | `agent.get-all` |
+| `GetBusinessLinesUseCaseImpl` | businessLine | `business-line.get-all` |
+| `GetGuaranteesUseCaseImpl` | guarantee | `guarantee.get-all` |
+| `GetRiskClassificationsUseCaseImpl` | riskClassification | `risk-classification.get-all` |
+| `GetSubscribersUseCaseImpl` | subscriber | `subscriber.get-all` |
+| `GetTariffsUseCaseImpl` | tariff | `tariff.get-all` |
+| `UpdateTariffsUseCaseImpl` | tariff | `tariff.update` |
+| `GetZipCodeUseCaseImpl` | zipcode | `zipcode.get` |
+| `ValidateZipCodeUseCaseImpl` | zipcode | `zipcode.validate` |
+
+Ejemplo de aplicación:
+
+```java
+@Observed(name = "folio.generate", contextualName = "generate-folio")
+public class GenerateFolioUseCaseImpl implements GenerateFolioUseCase {
+    // sin cambios en lógica
+}
+```
+
+---
+
+### 2.6 Métricas custom — diseño de clases
+
+#### Estructura de paquetes
+
+```
+infrastructure/metrics/
+├── FolioMetrics.java
+├── TariffMetrics.java
+├── ZipCodeMetrics.java
+├── AgentMetrics.java
+├── SubscriberMetrics.java
+└── CatalogErrorMetrics.java
+```
+
+Cada clase es un `@Component` que recibe `MeterRegistry` por constructor y registra sus contadores/timers en `@PostConstruct`.
+
+#### `FolioMetrics.java`
+
+```java
+@Component
+public class FolioMetrics {
+    private final Counter foliosGenerated;
+
+    public FolioMetrics(MeterRegistry registry) {
+        this.foliosGenerated = Counter.builder("folios_generated_total")
+            .description("Folios generados exitosamente")
+            .register(registry);
+    }
+
+    public void recordFolioGenerated() {
+        foliosGenerated.increment();
+    }
+}
+```
+
+#### `TariffMetrics.java`
+
+```java
+@Component
+public class TariffMetrics {
+    private final MeterRegistry registry;
+
+    public TariffMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordLookup(String fireKey) {
+        Counter.builder("tariff_lookups_total")
+            .tag("fireKey", fireKey)
+            .description("Consultas de tarifas por clave de incendio")
+            .register(registry)
+            .increment();
+    }
+
+    public Timer.Sample startTimer() {
+        return Timer.start(registry);
+    }
+
+    public void stopTimer(Timer.Sample sample, String fireKey) {
+        sample.stop(Timer.builder("tariff_lookup_duration_seconds")
+            .tag("fireKey", fireKey)
+            .description("Duración de consultas de tarifas")
+            .register(registry));
+    }
+}
+```
+
+#### `ZipCodeMetrics.java`
+
+```java
+@Component
+public class ZipCodeMetrics {
+    private final MeterRegistry registry;
+
+    public ZipCodeMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordLookup(boolean found) {
+        Counter.builder("zipcode_lookups_total")
+            .tag("found", String.valueOf(found))
+            .description("Búsquedas de código postal")
+            .register(registry)
+            .increment();
+    }
+}
+```
+
+#### `AgentMetrics.java`
+
+```java
+@Component
+public class AgentMetrics {
+    private final Counter agentQueries;
+
+    public AgentMetrics(MeterRegistry registry) {
+        this.agentQueries = Counter.builder("agent_queries_total")
+            .description("Consultas de agentes")
+            .register(registry);
+    }
+
+    public void recordQuery() {
+        agentQueries.increment();
+    }
+}
+```
+
+#### `SubscriberMetrics.java`
+
+```java
+@Component
+public class SubscriberMetrics {
+    private final Counter subscriberQueries;
+
+    public SubscriberMetrics(MeterRegistry registry) {
+        this.subscriberQueries = Counter.builder("subscriber_queries_total")
+            .description("Consultas de suscriptores")
+            .register(registry);
+    }
+
+    public void recordQuery() {
+        subscriberQueries.increment();
+    }
+}
+```
+
+#### `CatalogErrorMetrics.java`
+
+```java
+@Component
+public class CatalogErrorMetrics {
+    private final MeterRegistry registry;
+
+    public CatalogErrorMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordError(String errorType) {
+        Counter.builder("catalog_errors_total")
+            .tag("errorType", errorType)
+            .description("Errores en operaciones de catálogo")
+            .register(registry)
+            .increment();
+    }
+}
+```
+
+---
+
+### 2.7 Inyección de métricas en controladores/use cases
+
+Las métricas custom se inyectan en los controllers (para `folios_generated_total`, `agent_queries_total`, `subscriber_queries_total`, `zipcode_lookups_total`) o en los use case implementations (para `tariff_lookups_total`, `tariff_lookup_duration_seconds`).
+
+| Métrica | Punto de inyección | Justificación |
+|---|---|---|
+| `folios_generated_total` | `FolioController` (en respuesta 200) | Solo cuenta éxitos HTTP |
+| `tariff_lookups_total` / `tariff_lookup_duration_seconds` | `GetTariffsUseCaseImpl` | Necesita acceso al fireKey de dominio |
+| `zipcode_lookups_total` | `GetZipCodeUseCaseImpl` | Conoce si encontró o no el resultado |
+| `agent_queries_total` | `AgentController` | Simple contador por request exitoso |
+| `subscriber_queries_total` | `SubscriberController` | Simple contador por request exitoso |
+| `catalog_errors_total` | Global exception handler (`@RestControllerAdvice`) | Captura todos los errores de catálogo |
+
+---
+
+### 2.8 `compose.yaml` — servicios de observabilidad
+
+Agregar al `compose.yaml` existente (que ya tiene `postgres`):
+
+```yaml
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686"   # Jaeger UI
+      - "4317:4317"     # OTLP gRPC
+      - "4318:4318"     # OTLP HTTP
+    networks:
+      - observability
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9091:9090"     # Puerto 9091 para no colisionar con Back (9090)
+    networks:
+      - observability
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3001:3000"     # Puerto 3001 para no colisionar con Back (3000)
+    depends_on:
+      - prometheus
+    networks:
+      - observability
+
+networks:
+  observability:
+    driver: bridge
+```
+
+> **Nota de puertos**: Jaeger usa los mismos puertos (16686, 4317, 4318) que en Insurance-Quoter-Back. Si ambos `compose.yaml` se ejecutan simultáneamente en la misma máquina, los puertos de Jaeger colisionarán. La solución recomendada es ejecutar Jaeger solo desde uno de los dos proyectos (preferentemente Back) y que Core se conecte a ese mismo Jaeger. Documentar en README.
+
+---
+
+### 2.9 `observability/prometheus.yml`
+
+Archivo: `observability/prometheus.yml`
+
+```yaml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: insurance-quoter-core
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8081
+```
+
+> `host.docker.internal` permite que Prometheus dentro de Docker acceda a la aplicación Java corriendo en el host.
+
+---
+
+### 2.10 Endpoints actuator resultantes
+
+| Endpoint | Descripción |
+|---|---|
+| `GET /actuator/health` | Estado del servicio y DB |
+| `GET /actuator/metrics` | Lista de métricas disponibles |
+| `GET /actuator/prometheus` | Scrape endpoint para Prometheus |
+| `GET /actuator/info` | Info de la aplicación |
+
+---
+
+## 3. LISTA DE TAREAS
+
+### Backend
+
+#### Fase 1 — Infraestructura base
+- [ ] **T-001** Agregar dependencias de observabilidad en `build.gradle.kts`: `actuator`, `micrometer-registry-prometheus`, `micrometer-tracing-bridge-otel`, `opentelemetry-exporter-otlp`, `logstash-logback-encoder:8.0`, `spring-boot-starter-aop`
+- [ ] **T-002** Crear `src/main/resources/logback-spring.xml` con `LogstashEncoder` (JSON estructurado + traceId/spanId en MDC)
+- [ ] **T-003** Configurar `application.properties`: actuator endpoints, tracing sampling=1.0, OTLP endpoint, logging pattern
+- [ ] **T-004** Crear `ObservabilityConfig.java` en `infrastructure/config/` con `@EnableObservability` y bean `ObservedAspect`
+
+#### Fase 2 — `@Observed` en use cases
+- [ ] **T-005** Agregar `@Observed(name="folio.generate")` en `GenerateFolioUseCaseImpl`
+- [ ] **T-006** Agregar `@Observed(name="agent.get-all")` en `GetAgentsUseCaseImpl`
+- [ ] **T-007** Agregar `@Observed(name="business-line.get-all")` en `GetBusinessLinesUseCaseImpl`
+- [ ] **T-008** Agregar `@Observed(name="guarantee.get-all")` en `GetGuaranteesUseCaseImpl`
+- [ ] **T-009** Agregar `@Observed(name="risk-classification.get-all")` en `GetRiskClassificationsUseCaseImpl`
+- [ ] **T-010** Agregar `@Observed(name="subscriber.get-all")` en `GetSubscribersUseCaseImpl`
+- [ ] **T-011** Agregar `@Observed(name="tariff.get-all")` en `GetTariffsUseCaseImpl`
+- [ ] **T-012** Agregar `@Observed(name="tariff.update")` en `UpdateTariffsUseCaseImpl`
+- [ ] **T-013** Agregar `@Observed(name="zipcode.get")` en `GetZipCodeUseCaseImpl`
+- [ ] **T-014** Agregar `@Observed(name="zipcode.validate")` en `ValidateZipCodeUseCaseImpl`
+
+#### Fase 3 — Métricas custom
+- [ ] **T-015** Crear `FolioMetrics.java` en `infrastructure/metrics/` con counter `folios_generated_total`; inyectar en `FolioController`
+- [ ] **T-016** Crear `TariffMetrics.java` con counter `tariff_lookups_total{fireKey}` y timer `tariff_lookup_duration_seconds{fireKey}`; inyectar en `GetTariffsUseCaseImpl`
+- [ ] **T-017** Crear `ZipCodeMetrics.java` con counter `zipcode_lookups_total{found}`; inyectar en `GetZipCodeUseCaseImpl`
+- [ ] **T-018** Crear `AgentMetrics.java` con counter `agent_queries_total`; inyectar en `AgentController`
+- [ ] **T-019** Crear `SubscriberMetrics.java` con counter `subscriber_queries_total`; inyectar en `SubscriberController`
+- [ ] **T-020** Crear `CatalogErrorMetrics.java` con counter `catalog_errors_total{errorType}`; inyectar en `@RestControllerAdvice` global
+
+#### Fase 4 — Docker Compose e infraestructura
+- [ ] **T-021** Agregar servicios `jaeger`, `prometheus`, `grafana` al `compose.yaml` existente con puertos diferenciados (Prometheus: 9091, Grafana: 3001)
+- [ ] **T-022** Crear `observability/prometheus.yml` con `job_name: insurance-quoter-core` apuntando a `host.docker.internal:8081/actuator/prometheus`
+
+#### Fase 5 — Tests unitarios (TDD)
+- [ ] **T-023** Test unitario para `FolioMetrics`: verificar que `recordFolioGenerated()` incrementa el counter
+- [ ] **T-024** Test unitario para `TariffMetrics`: verificar counter por fireKey y que el timer registra duración
+- [ ] **T-025** Test unitario para `ZipCodeMetrics`: verificar counter con tags `found=true` y `found=false`
+- [ ] **T-026** Test unitario para `AgentMetrics`: verificar counter
+- [ ] **T-027** Test unitario para `SubscriberMetrics`: verificar counter
+- [ ] **T-028** Test unitario para `CatalogErrorMetrics`: verificar counter por errorType
+- [ ] **T-029** Test de integración (`@SpringBootTest`): verificar que `/actuator/prometheus` devuelve 200 y contiene `jvm_memory_used_bytes`, `http_server_requests_seconds`, `hikaricp_connections_active`
+- [ ] **T-030** Test de integración: verificar que `ObservabilityConfig` registra `ObservedAspect` en el contexto de Spring
+
+### Frontend
+> No aplica — este feature es exclusivamente backend.
+
+### QA / Validación manual
+- [ ] Arrancar la app y verificar que `/actuator/health` devuelve `{"status":"UP"}`
+- [ ] Verificar que `/actuator/prometheus` expone métricas JVM, HTTP y custom
+- [ ] Ejecutar GET /v1/folios y confirmar `folios_generated_total` incrementa en Prometheus
+- [ ] Ejecutar GET /v1/tariffs con `fireKey` y confirmar counter + timer en Prometheus
+- [ ] Ejecutar GET /v1/zip-codes/{code} con código existente y no existente; confirmar tags `found=true/false`
+- [ ] Confirmar en Jaeger UI (http://localhost:16686) que el servicio `insurance-quoter-core` aparece
+- [ ] Enviar request con header `traceparent` de Back y verificar en Jaeger que Core continúa la misma traza (mismo traceId)
+- [ ] Verificar en logs JSON que `traceId` y `spanId` están presentes y no vacíos

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Microservicio de referencia del cotizador de seguros de daños. Provee catálogo
 - Java 21 + Spring Boot 4 + Spring Data JPA
 - PostgreSQL (puerto **5433** en desarrollo)
 - Arquitectura hexagonal (ports & adapters)
+- Observabilidad: Actuator + Micrometer + OpenTelemetry + Logback JSON
 
 ## Puerto
-- **8081** (development)
+- **8081** (desarrollo)
 
 ## Endpoints que expone
 
@@ -29,12 +30,74 @@ Ver contratos completos en `docs/api-contracts.md` — sección 8.
 
 ## Ejecución local
 
+### 1. Levantar infraestructura
+
 ```bash
 cd Insurance-Quoter-Core
+docker compose up -d
+```
+
+Servicios disponibles tras el comando:
+
+| Servicio | URL | Credenciales |
+|----------|-----|-------------|
+| PostgreSQL | `localhost:5433` | via variables de entorno |
+| Jaeger UI | http://localhost:16686 | — |
+| Prometheus | http://localhost:9091 | — |
+| Grafana | http://localhost:3001 | admin / admin |
+
+> **Nota de Jaeger**: se levanta un Jaeger por proyecto. Si Insurance-Quoter-Back ya tiene uno corriendo en los puertos 4317/16686, detén el de Core antes de arrancar ambos compose simultáneamente.
+
+### 2. Arrancar la aplicación
+
+Requiere variables de entorno `DB_USERNAME` y `DB_PASSWORD` (archivo `.env` en la raíz del proyecto):
+
+```bash
 ./gradlew bootRun
 ```
 
-PostgreSQL se levanta automáticamente con Docker Compose en el puerto 5433.
+La app arranca en `http://localhost:8081`.  
+Swagger UI: http://localhost:8081/swagger-ui/index.html
+
+### 3. Verificar observabilidad
+
+```bash
+# Health
+curl http://localhost:8081/actuator/health
+
+# Métricas Prometheus
+curl http://localhost:8081/actuator/prometheus
+```
+
+Prometheus empieza a scrapear `/actuator/prometheus` cada 15 s. Las métricas aparecen en Grafana tras el primer scrape.
+
+## Observabilidad (3 pilares)
+
+### Logs estructurados
+Cada línea de log es JSON con `traceId` y `spanId` en el MDC:
+```json
+{"@timestamp":"...","level":"INFO","service":"Insurance-Quoter-Core","traceId":"abc123","spanId":"def456","message":"..."}
+```
+
+### Métricas custom (Prometheus)
+
+| Métrica | Tipo | Descripción |
+|---------|------|-------------|
+| `folios_generated_total` | Counter | Folios generados exitosamente |
+| `tariff_lookups_total` | Counter | Consultas al catálogo de tarifas |
+| `tariff_lookup_duration_seconds` | Timer | Duración de consultas de tarifas |
+| `zipcode_lookups_total{found}` | Counter | Búsquedas de CP (tag: `found=true\|false`) |
+| `agent_queries_total` | Counter | Consultas de agentes |
+| `subscriber_queries_total` | Counter | Consultas de suscriptores |
+| `catalog_errors_total{errorType}` | Counter | Errores no manejados por contexto |
+
+Más métricas automáticas: JVM (`jvm_memory_*`), HTTP (`http_server_requests_seconds`), pool de conexiones (`hikaricp_connections_*`).
+
+### Trazas distribuidas
+- Propaga el header W3C `traceparent` recibido desde Insurance-Quoter-Back — no crea un root trace nuevo
+- `@Observed` en los 10 use cases genera un span por invocación
+- Exporta a Jaeger vía OTLP gRPC (`localhost:4317`)
+- Spans JDBC registrados automáticamente
 
 ## Nota
 El folder `src/.../Insurance_Quoter/` es residuo de la copia inicial y puede eliminarse manualmente. El punto de entrada activo es `com.sofka.insurancequoter.core.InsuranceQuoterCoreApplication`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,15 @@ dependencies {
 	runtimeOnly("org.postgresql:postgresql")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")
+	// Observability — metrics, tracing, logs
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.micrometer:micrometer-registry-prometheus")
+	implementation("io.micrometer:micrometer-tracing-bridge-otel")
+	implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+	// AspectJ weaver is brought transitively by spring-boot-starter-webmvc;
+	// declaring it explicitly ensures @Observed AOP works at compile time.
+	implementation("org.aspectj:aspectjweaver")
+	implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.4")

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,15 +13,40 @@ services:
       timeout: 5s
       retries: 10
 
-  app:
-    build: .
-    ports:
-      - '8081:8081'
+  #app:
+  #  build: .
+  #  ports:
+  #    - '8081:8081'
+  #  environment:
+  #    - 'DB_URL=jdbc:postgresql://postgres:5432/insurance_core_db'
+  #    - 'DB_USERNAME=${DB_USERNAME}'
+  #    - 'DB_PASSWORD=${DB_PASSWORD}'
+  #    - 'SPRING_DOCKER_COMPOSE_ENABLED=false'
+  #  depends_on:
+  #    postgres:
+  #      condition: service_healthy
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
     environment:
-      - 'DB_URL=jdbc:postgresql://postgres:5432/insurance_core_db'
-      - 'DB_USERNAME=${DB_USERNAME}'
-      - 'DB_PASSWORD=${DB_PASSWORD}'
-      - 'SPRING_DOCKER_COMPOSE_ENABLED=false'
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9091:9090"
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3001:3000"
     depends_on:
-      postgres:
-        condition: service_healthy
+      - prometheus

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: insurance-quoter-core
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8081

--- a/src/main/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/application/usecase/GetAgentsUseCaseImpl.java
@@ -3,9 +3,15 @@ package com.sofka.insurancequoter.core.agent.application.usecase;
 import com.sofka.insurancequoter.core.agent.domain.model.Agent;
 import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
 import com.sofka.insurancequoter.core.agent.domain.port.out.AgentRepository;
+import io.micrometer.observation.annotation.Observed;
 
 import java.util.List;
 
+/**
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ * The Spring @Bean proxy in AgentConfig enables AOP interception.
+ */
+@Observed(name = "agent.get-all", contextualName = "get-agents")
 public class GetAgentsUseCaseImpl implements GetAgentsUseCase {
 
     private final AgentRepository agentRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentController.java
@@ -4,19 +4,28 @@ import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper.AgentRestMapper;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.swaggerdocs.AgentApi;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.AgentMetrics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST controller for the Agents resource.
+ * Records agent_queries_total metric on every successful response.
+ */
 @RestController
 @RequiredArgsConstructor
 public class AgentController implements AgentApi {
 
     private final GetAgentsUseCase getAgentsUseCase;
     private final AgentRestMapper agentRestMapper;
+    private final AgentMetrics agentMetrics;
 
     @Override
     public ResponseEntity<AgentsResponse> getAgents() {
-        return ResponseEntity.ok(agentRestMapper.toResponse(getAgentsUseCase.getAll()));
+        ResponseEntity<AgentsResponse> response = ResponseEntity.ok(
+                agentRestMapper.toResponse(getAgentsUseCase.getAll()));
+        agentMetrics.recordQuery();
+        return response;
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/businessline/application/usecase/GetBusinessLinesUseCaseImpl.java
@@ -3,9 +3,14 @@ package com.sofka.insurancequoter.core.businessline.application.usecase;
 import com.sofka.insurancequoter.core.businessline.domain.model.BusinessLine;
 import com.sofka.insurancequoter.core.businessline.domain.port.in.GetBusinessLinesUseCase;
 import com.sofka.insurancequoter.core.businessline.domain.port.out.BusinessLineRepository;
+import io.micrometer.observation.annotation.Observed;
 
 import java.util.List;
 
+/**
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ */
+@Observed(name = "business-line.get-all", contextualName = "get-business-lines")
 public class GetBusinessLinesUseCaseImpl implements GetBusinessLinesUseCase {
 
     private final BusinessLineRepository businessLineRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/folio/application/usecase/GenerateFolioUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/folio/application/usecase/GenerateFolioUseCaseImpl.java
@@ -3,6 +3,7 @@ package com.sofka.insurancequoter.core.folio.application.usecase;
 import com.sofka.insurancequoter.core.folio.domain.model.Folio;
 import com.sofka.insurancequoter.core.folio.domain.port.in.GenerateFolioUseCase;
 import com.sofka.insurancequoter.core.folio.domain.port.out.FolioSequencePort;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 
 import java.time.Clock;
@@ -12,7 +13,11 @@ import java.time.Instant;
  * Application use case — orchestrates folio generation.
  * Not annotated with @Service; registered as a @Bean in FolioConfig to keep
  * the application layer free of Spring infrastructure annotations.
+ *
+ * @Observed generates a trace span and timer metric per method invocation.
+ * The AOP proxy is created by Spring because this class is returned by a @Bean factory.
  */
+@Observed(name = "folio.generate", contextualName = "generate-folio")
 @RequiredArgsConstructor
 public class GenerateFolioUseCaseImpl implements GenerateFolioUseCase {
 

--- a/src/main/java/com/sofka/insurancequoter/core/folio/infrastructure/adapter/in/rest/FolioController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/folio/infrastructure/adapter/in/rest/FolioController.java
@@ -4,6 +4,7 @@ import com.sofka.insurancequoter.core.folio.domain.port.in.GenerateFolioUseCase;
 import com.sofka.insurancequoter.core.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
 import com.sofka.insurancequoter.core.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
 import com.sofka.insurancequoter.core.folio.infrastructure.adapter.in.rest.swaggerdocs.FolioApi;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.FolioMetrics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
  * REST controller for the Folios resource.
  * Parses HTTP, delegates to the use case, and maps the result to a DTO.
  * No business logic — no Swagger annotations (those live in FolioApi).
+ * Records folios_generated_total metric on every successful response.
  */
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +21,13 @@ public class FolioController implements FolioApi {
 
     private final GenerateFolioUseCase generateFolioUseCase;
     private final FolioRestMapper folioRestMapper;
+    private final FolioMetrics folioMetrics;
 
     @Override
     public ResponseEntity<FolioResponse> getFolio() {
-        return ResponseEntity.ok(folioRestMapper.toResponse(generateFolioUseCase.generate()));
+        ResponseEntity<FolioResponse> response = ResponseEntity.ok(
+                folioRestMapper.toResponse(generateFolioUseCase.generate()));
+        folioMetrics.recordFolioGenerated();
+        return response;
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/core/guarantee/application/usecase/GetGuaranteesUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/guarantee/application/usecase/GetGuaranteesUseCaseImpl.java
@@ -3,9 +3,14 @@ package com.sofka.insurancequoter.core.guarantee.application.usecase;
 import com.sofka.insurancequoter.core.guarantee.domain.model.Guarantee;
 import com.sofka.insurancequoter.core.guarantee.domain.port.in.GetGuaranteesUseCase;
 import com.sofka.insurancequoter.core.guarantee.domain.port.out.GuaranteeRepository;
+import io.micrometer.observation.annotation.Observed;
 
 import java.util.List;
 
+/**
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ */
+@Observed(name = "guarantee.get-all", contextualName = "get-guarantees")
 public class GetGuaranteesUseCaseImpl implements GetGuaranteesUseCase {
 
     private final GuaranteeRepository guaranteeRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/riskclassification/application/usecase/GetRiskClassificationsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/riskclassification/application/usecase/GetRiskClassificationsUseCaseImpl.java
@@ -3,9 +3,14 @@ package com.sofka.insurancequoter.core.riskclassification.application.usecase;
 import com.sofka.insurancequoter.core.riskclassification.domain.model.RiskClassification;
 import com.sofka.insurancequoter.core.riskclassification.domain.port.in.GetRiskClassificationsUseCase;
 import com.sofka.insurancequoter.core.riskclassification.domain.port.out.RiskClassificationRepository;
+import io.micrometer.observation.annotation.Observed;
 
 import java.util.List;
 
+/**
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ */
+@Observed(name = "risk-classification.get-all", contextualName = "get-risk-classifications")
 public class GetRiskClassificationsUseCaseImpl implements GetRiskClassificationsUseCase {
 
     private final RiskClassificationRepository riskClassificationRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/config/ObservabilityConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/config/ObservabilityConfig.java
@@ -1,0 +1,23 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures AOP support for @Observed annotations on use case implementations.
+ * The ObservedAspect intercepts methods on Spring-managed beans annotated with @Observed
+ * and creates a Micrometer observation (timer + trace span) for each invocation.
+ *
+ * Use cases are registered as @Bean in their respective *Config classes, so Spring
+ * creates a proxy that allows the aspect to intercept calls correctly.
+ */
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    public ObservedAspect observedAspect(ObservationRegistry registry) {
+        return new ObservedAspect(registry);
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/AgentMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/AgentMetrics.java
@@ -1,0 +1,25 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for the agent bounded context.
+ * Tracks the number of agent catalog queries.
+ */
+@Component
+public class AgentMetrics {
+
+    private final Counter agentQueries;
+
+    public AgentMetrics(MeterRegistry registry) {
+        this.agentQueries = Counter.builder("agent_queries_total")
+                .description("Number of agent catalog queries")
+                .register(registry);
+    }
+
+    public void recordQuery() {
+        agentQueries.increment();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/CatalogErrorMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/CatalogErrorMetrics.java
@@ -1,0 +1,29 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for catalog error tracking.
+ * Counts errors by their Java class simple name (e.g. "TariffNotFoundException").
+ * The errorType tag comes from exception class names — these are controlled values,
+ * not from free user input, so cardinality remains bounded.
+ */
+@Component
+public class CatalogErrorMetrics {
+
+    private final MeterRegistry registry;
+
+    public CatalogErrorMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordError(String errorType) {
+        Counter.builder("catalog_errors_total")
+                .tag("errorType", errorType)
+                .description("Number of catalog errors by type")
+                .register(registry)
+                .increment();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/FolioMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/FolioMetrics.java
@@ -1,0 +1,25 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for the folio bounded context.
+ * Tracks the number of folios successfully generated.
+ */
+@Component
+public class FolioMetrics {
+
+    private final Counter foliosGenerated;
+
+    public FolioMetrics(MeterRegistry registry) {
+        this.foliosGenerated = Counter.builder("folios_generated_total")
+                .description("Number of folios successfully generated")
+                .register(registry);
+    }
+
+    public void recordFolioGenerated() {
+        foliosGenerated.increment();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/SubscriberMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/SubscriberMetrics.java
@@ -1,0 +1,25 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for the subscriber bounded context.
+ * Tracks the number of subscriber catalog queries.
+ */
+@Component
+public class SubscriberMetrics {
+
+    private final Counter subscriberQueries;
+
+    public SubscriberMetrics(MeterRegistry registry) {
+        this.subscriberQueries = Counter.builder("subscriber_queries_total")
+                .description("Number of subscriber catalog queries")
+                .register(registry);
+    }
+
+    public void recordQuery() {
+        subscriberQueries.increment();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/TariffMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/TariffMetrics.java
@@ -1,0 +1,42 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for the tariff bounded context.
+ *
+ * Domain adaptation: The Tariffs domain model is a single-row catalog record with no fireKey field.
+ * The spec originally requested tariff_lookups_total{fireKey} and tariff_lookup_duration_seconds{fireKey},
+ * but since fireKey does not exist in the Tariffs record, both metrics are implemented without that tag.
+ * This avoids coupling the metrics layer to an artificial concept not present in the domain.
+ */
+@Component
+public class TariffMetrics {
+
+    private final Counter lookupCounter;
+    private final MeterRegistry registry;
+
+    public TariffMetrics(MeterRegistry registry) {
+        this.registry = registry;
+        this.lookupCounter = Counter.builder("tariff_lookups_total")
+                .description("Number of tariff catalog lookups")
+                .register(registry);
+    }
+
+    public void recordLookup() {
+        lookupCounter.increment();
+    }
+
+    public Timer.Sample startTimer() {
+        return Timer.start(registry);
+    }
+
+    public void stopTimer(Timer.Sample sample) {
+        sample.stop(Timer.builder("tariff_lookup_duration_seconds")
+                .description("Duration of tariff catalog lookups")
+                .register(registry));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/ZipCodeMetrics.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/ZipCodeMetrics.java
@@ -1,0 +1,27 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom metrics for the zipcode bounded context.
+ * Tracks zip code lookups tagged by whether the code was found or not.
+ */
+@Component
+public class ZipCodeMetrics {
+
+    private final MeterRegistry registry;
+
+    public ZipCodeMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordLookup(boolean found) {
+        Counter.builder("zipcode_lookups_total")
+                .tag("found", String.valueOf(found))
+                .description("Number of zip code lookups, tagged by result")
+                .register(registry)
+                .increment();
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/rest/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.rest;
+
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.CatalogErrorMetrics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+/**
+ * Global fallback exception handler for all unhandled exceptions.
+ * Controllers may define their own @ExceptionHandler for domain-specific exceptions
+ * (e.g. TariffController handles TariffNotFoundException locally). This handler
+ * only activates when no local handler matches — it acts as a safety net.
+ *
+ * Records catalog_errors_total{errorType} for every unhandled exception so that
+ * unexpected failure patterns become visible in Prometheus/Grafana dashboards.
+ */
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final CatalogErrorMetrics catalogErrorMetrics;
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericError(Exception ex) {
+        catalogErrorMetrics.recordError(ex.getClass().getSimpleName());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of(
+                        "error", "Internal server error",
+                        "code", "CATALOG_ERROR"
+                ));
+    }
+}

--- a/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/rest/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofka/insurancequoter/core/shared/infrastructure/rest/GlobalExceptionHandler.java
@@ -6,21 +6,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Map;
 
 /**
  * Global fallback exception handler for all unhandled exceptions.
- * Controllers may define their own @ExceptionHandler for domain-specific exceptions
- * (e.g. TariffController handles TariffNotFoundException locally). This handler
- * only activates when no local handler matches — it acts as a safety net.
+ * Extends ResponseEntityExceptionHandler so Spring's built-in handlers for
+ * validation exceptions (MethodArgumentNotValidException → 400, etc.) take
+ * precedence over the generic Exception handler below.
  *
- * Records catalog_errors_total{errorType} for every unhandled exception so that
- * unexpected failure patterns become visible in Prometheus/Grafana dashboards.
+ * Records catalog_errors_total{errorType} for every truly unhandled exception
+ * so unexpected failure patterns become visible in Prometheus/Grafana.
  */
 @RestControllerAdvice
 @RequiredArgsConstructor
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private final CatalogErrorMetrics catalogErrorMetrics;
 

--- a/src/main/java/com/sofka/insurancequoter/core/subscriber/application/usecase/GetSubscribersUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/subscriber/application/usecase/GetSubscribersUseCaseImpl.java
@@ -3,10 +3,15 @@ package com.sofka.insurancequoter.core.subscriber.application.usecase;
 import com.sofka.insurancequoter.core.subscriber.domain.model.Subscriber;
 import com.sofka.insurancequoter.core.subscriber.domain.port.in.GetSubscribersUseCase;
 import com.sofka.insurancequoter.core.subscriber.domain.port.out.SubscriberRepository;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+/**
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ */
+@Observed(name = "subscriber.get-all", contextualName = "get-subscribers")
 @RequiredArgsConstructor
 public class GetSubscribersUseCaseImpl implements GetSubscribersUseCase {
 

--- a/src/main/java/com/sofka/insurancequoter/core/subscriber/infrastructure/adapter/in/rest/SubscriberController.java
+++ b/src/main/java/com/sofka/insurancequoter/core/subscriber/infrastructure/adapter/in/rest/SubscriberController.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.core.subscriber.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.SubscriberMetrics;
 import com.sofka.insurancequoter.core.subscriber.domain.port.in.GetSubscribersUseCase;
 import com.sofka.insurancequoter.core.subscriber.infrastructure.adapter.in.rest.dto.SubscribersResponse;
 import com.sofka.insurancequoter.core.subscriber.infrastructure.adapter.in.rest.mapper.SubscriberRestMapper;
@@ -8,15 +9,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST controller for the Subscribers resource.
+ * Records subscriber_queries_total metric on every successful response.
+ */
 @RestController
 @RequiredArgsConstructor
 public class SubscriberController implements SubscriberApi {
 
     private final GetSubscribersUseCase getSubscribersUseCase;
     private final SubscriberRestMapper subscriberRestMapper;
+    private final SubscriberMetrics subscriberMetrics;
 
     @Override
     public ResponseEntity<SubscribersResponse> getSubscribers() {
-        return ResponseEntity.ok(subscriberRestMapper.toResponse(getSubscribersUseCase.getAll()));
+        ResponseEntity<SubscribersResponse> response = ResponseEntity.ok(
+                subscriberRestMapper.toResponse(getSubscribersUseCase.getAll()));
+        subscriberMetrics.recordQuery();
+        return response;
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/core/tariff/application/usecase/GetTariffsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/tariff/application/usecase/GetTariffsUseCaseImpl.java
@@ -4,22 +4,39 @@ import com.sofka.insurancequoter.core.tariff.domain.exception.TariffNotFoundExce
 import com.sofka.insurancequoter.core.tariff.domain.model.Tariffs;
 import com.sofka.insurancequoter.core.tariff.domain.port.in.GetTariffsUseCase;
 import com.sofka.insurancequoter.core.tariff.domain.port.out.TariffRepository;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.TariffMetrics;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.annotation.Observed;
 
 /**
  * Use case implementation that retrieves the current tariff catalog.
  * Throws TariffNotFoundException if the catalog has not been seeded.
+ *
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ * TariffMetrics records tariff_lookups_total (counter) and tariff_lookup_duration_seconds (timer).
+ * No fireKey tag — the Tariffs domain model is a single-row catalog with no fireKey field.
  */
+@Observed(name = "tariff.get-all", contextualName = "get-tariffs")
 public class GetTariffsUseCaseImpl implements GetTariffsUseCase {
 
     private final TariffRepository tariffRepository;
+    private final TariffMetrics tariffMetrics;
 
-    public GetTariffsUseCaseImpl(TariffRepository tariffRepository) {
+    public GetTariffsUseCaseImpl(TariffRepository tariffRepository, TariffMetrics tariffMetrics) {
         this.tariffRepository = tariffRepository;
+        this.tariffMetrics = tariffMetrics;
     }
 
     @Override
     public Tariffs getCurrent() {
-        return tariffRepository.findCurrent()
-                .orElseThrow(TariffNotFoundException::new);
+        Timer.Sample sample = tariffMetrics.startTimer();
+        try {
+            Tariffs result = tariffRepository.findCurrent()
+                    .orElseThrow(TariffNotFoundException::new);
+            tariffMetrics.recordLookup();
+            return result;
+        } finally {
+            tariffMetrics.stopTimer(sample);
+        }
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/core/tariff/application/usecase/UpdateTariffsUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/tariff/application/usecase/UpdateTariffsUseCaseImpl.java
@@ -4,11 +4,15 @@ import com.sofka.insurancequoter.core.tariff.domain.exception.TariffNotFoundExce
 import com.sofka.insurancequoter.core.tariff.domain.model.Tariffs;
 import com.sofka.insurancequoter.core.tariff.domain.port.in.UpdateTariffsUseCase;
 import com.sofka.insurancequoter.core.tariff.domain.port.out.TariffRepository;
+import io.micrometer.observation.annotation.Observed;
 
 /**
  * Use case implementation that updates the tariff catalog.
  * Verifies existence via findCurrent() before persisting the new values.
+ *
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
  */
+@Observed(name = "tariff.update", contextualName = "update-tariffs")
 public class UpdateTariffsUseCaseImpl implements UpdateTariffsUseCase {
 
     private final TariffRepository tariffRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/tariff/infrastructure/config/TariffConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/tariff/infrastructure/config/TariffConfig.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.core.tariff.infrastructure.config;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.TariffMetrics;
 import com.sofka.insurancequoter.core.tariff.application.usecase.GetTariffsUseCaseImpl;
 import com.sofka.insurancequoter.core.tariff.application.usecase.UpdateTariffsUseCaseImpl;
 import com.sofka.insurancequoter.core.tariff.domain.port.in.GetTariffsUseCase;
@@ -11,13 +12,14 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Spring configuration for the tariff bounded context.
  * Wires use case implementations so no @Service annotation is needed in the application layer.
+ * TariffMetrics is injected into GetTariffsUseCaseImpl to record lookup counters and timers.
  */
 @Configuration
 public class TariffConfig {
 
     @Bean
-    public GetTariffsUseCase getTariffsUseCase(TariffRepository tariffRepository) {
-        return new GetTariffsUseCaseImpl(tariffRepository);
+    public GetTariffsUseCase getTariffsUseCase(TariffRepository tariffRepository, TariffMetrics tariffMetrics) {
+        return new GetTariffsUseCaseImpl(tariffRepository, tariffMetrics);
     }
 
     @Bean

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImpl.java
@@ -4,22 +4,37 @@ import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundEx
 import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
 import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
 import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.ZipCodeMetrics;
+import io.micrometer.observation.annotation.Observed;
 
 /**
  * Use case implementation — retrieves full zip code data.
  * Registered as @Bean via ZipCodeConfig (no @Service annotation).
+ *
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
+ * ZipCodeMetrics records zipcode_lookups_total{found=true|false} on each call.
  */
+@Observed(name = "zipcode.get", contextualName = "get-zipcode")
 public class GetZipCodeUseCaseImpl implements GetZipCodeUseCase {
 
     private final ZipCodeRepository zipCodeRepository;
+    private final ZipCodeMetrics zipCodeMetrics;
 
-    public GetZipCodeUseCaseImpl(ZipCodeRepository zipCodeRepository) {
+    public GetZipCodeUseCaseImpl(ZipCodeRepository zipCodeRepository, ZipCodeMetrics zipCodeMetrics) {
         this.zipCodeRepository = zipCodeRepository;
+        this.zipCodeMetrics = zipCodeMetrics;
     }
 
     @Override
     public ZipCode getByZipCode(String zipCode) {
         return zipCodeRepository.findByZipCode(zipCode)
-                .orElseThrow(() -> new ZipCodeNotFoundException(zipCode));
+                .map(result -> {
+                    zipCodeMetrics.recordLookup(true);
+                    return result;
+                })
+                .orElseThrow(() -> {
+                    zipCodeMetrics.recordLookup(false);
+                    return new ZipCodeNotFoundException(zipCode);
+                });
     }
 }

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImpl.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/application/usecase/ValidateZipCodeUseCaseImpl.java
@@ -3,11 +3,15 @@ package com.sofka.insurancequoter.core.zipcode.application.usecase;
 import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCodeValidationResult;
 import com.sofka.insurancequoter.core.zipcode.domain.port.in.ValidateZipCodeUseCase;
 import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import io.micrometer.observation.annotation.Observed;
 
 /**
  * Use case implementation — validates zip code existence.
  * Always returns a result; never throws. Registered as @Bean via ZipCodeConfig.
+ *
+ * @Observed creates a trace span per invocation via ObservedAspect (registered in ObservabilityConfig).
  */
+@Observed(name = "zipcode.validate", contextualName = "validate-zipcode")
 public class ValidateZipCodeUseCaseImpl implements ValidateZipCodeUseCase {
 
     private final ZipCodeRepository zipCodeRepository;

--- a/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/config/ZipCodeConfig.java
+++ b/src/main/java/com/sofka/insurancequoter/core/zipcode/infrastructure/config/ZipCodeConfig.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.core.zipcode.infrastructure.config;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.ZipCodeMetrics;
 import com.sofka.insurancequoter.core.zipcode.application.usecase.GetZipCodeUseCaseImpl;
 import com.sofka.insurancequoter.core.zipcode.application.usecase.ValidateZipCodeUseCaseImpl;
 import com.sofka.insurancequoter.core.zipcode.domain.port.in.GetZipCodeUseCase;
@@ -12,13 +13,14 @@ import org.springframework.context.annotation.Configuration;
  * Spring configuration for the zipcode bounded context.
  * Wires use case implementations without placing Spring annotations in the application layer.
  * ZipCodePersistenceAdapter is @Component and satisfies ZipCodeRepository automatically.
+ * ZipCodeMetrics is injected into GetZipCodeUseCaseImpl to record lookup counters.
  */
 @Configuration
 public class ZipCodeConfig {
 
     @Bean
-    public GetZipCodeUseCase getZipCodeUseCase(ZipCodeRepository zipCodeRepository) {
-        return new GetZipCodeUseCaseImpl(zipCodeRepository);
+    public GetZipCodeUseCase getZipCodeUseCase(ZipCodeRepository zipCodeRepository, ZipCodeMetrics zipCodeMetrics) {
+        return new GetZipCodeUseCaseImpl(zipCodeRepository, zipCodeMetrics);
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 # JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # Flyway
@@ -21,3 +22,22 @@ spring.flyway.locations=classpath:db/migration
 logging.level.root=WARN
 logging.level.com.sofka.insurancequoter=INFO
 logging.level.org.flywaydb=INFO
+logging.level.org.springframework.boot.web.embedded.tomcat=INFO
+logging.level.org.hibernate.orm.deprecation=ERROR
+logging.level.org.hibernate.orm.connections=ERROR
+logging.level.com.zaxxer.hikari=ERROR
+logging.level.org.springframework.orm.jpa=ERROR
+
+# Actuator
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
+management.endpoint.health.show-details=always
+management.metrics.tags.application=${spring.application.name}
+management.metrics.tags.environment=${spring.profiles.active:local}
+
+# Tracing
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=http://localhost:4317
+management.otlp.tracing.compression=gzip
+
+# Logging pattern with traceId/spanId
+logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <customFields>{"service":"${appName}"}</customFields>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+  <logger name="com.sofka.insurancequoter" level="DEBUG"/>
+</configuration>

--- a/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/agent/infrastructure/adapter/in/rest/AgentControllerTest.java
@@ -5,6 +5,7 @@ import com.sofka.insurancequoter.core.agent.domain.port.in.GetAgentsUseCase;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentDto;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.dto.AgentsResponse;
 import com.sofka.insurancequoter.core.agent.infrastructure.adapter.in.rest.mapper.AgentRestMapper;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.AgentMetrics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,6 +27,9 @@ class AgentControllerTest {
 
     @Mock
     private AgentRestMapper agentRestMapper;
+
+    @Mock
+    private AgentMetrics agentMetrics;
 
     @InjectMocks
     private AgentController controller;

--- a/src/test/java/com/sofka/insurancequoter/core/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/folio/infrastructure/adapter/in/rest/FolioControllerTest.java
@@ -4,6 +4,7 @@ import com.sofka.insurancequoter.core.folio.domain.model.Folio;
 import com.sofka.insurancequoter.core.folio.domain.port.in.GenerateFolioUseCase;
 import com.sofka.insurancequoter.core.folio.infrastructure.adapter.in.rest.dto.FolioResponse;
 import com.sofka.insurancequoter.core.folio.infrastructure.adapter.in.rest.mapper.FolioRestMapper;
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.FolioMetrics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,6 +26,9 @@ class FolioControllerTest {
 
     @Mock
     private FolioRestMapper folioRestMapper;
+
+    @Mock
+    private FolioMetrics folioMetrics;
 
     @InjectMocks
     private FolioController controller;

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/ActuatorPrometheusIntegrationTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/ActuatorPrometheusIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.sofka.insurancequoter.core.shared.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test — T-029.
+ * Verifies that GET /actuator/prometheus returns HTTP 200 and exposes JVM metrics.
+ * Jaeger and Prometheus containers are NOT started here — they are external infrastructure.
+ * The OTLP exporter will fail silently (no Jaeger running) which does not affect the test.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class ActuatorPrometheusIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        // Disable OTLP tracing export so missing Jaeger does not break the test
+        registry.add("management.otlp.tracing.endpoint", () -> "http://localhost:14317");
+    }
+
+    @LocalServerPort
+    int port;
+
+    private RestClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = RestClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .build();
+    }
+
+    @Test
+    void actuatorPrometheus_returns200() {
+        // WHEN
+        ResponseEntity<String> response = client.get()
+                .uri("/actuator/prometheus")
+                .retrieve()
+                .toEntity(String.class);
+
+        // THEN
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+    }
+
+    @Test
+    void actuatorPrometheus_containsJvmMemoryMetric() {
+        // WHEN
+        String body = client.get()
+                .uri("/actuator/prometheus")
+                .retrieve()
+                .body(String.class);
+
+        // THEN
+        assertThat(body).contains("jvm_memory_used_bytes");
+    }
+
+    @Test
+    void actuatorPrometheus_containsHikariMetric() {
+        // WHEN
+        String body = client.get()
+                .uri("/actuator/prometheus")
+                .retrieve()
+                .body(String.class);
+
+        // THEN — HikariCP metrics are exposed when a DataSource is configured
+        assertThat(body).contains("hikaricp_connections");
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/ObservabilityConfigTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/ObservabilityConfigTest.java
@@ -1,0 +1,58 @@
+package com.sofka.insurancequoter.core.shared.infrastructure;
+
+import io.micrometer.observation.aop.ObservedAspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test — T-030.
+ * Verifies that ObservabilityConfig registers ObservedAspect in the Spring context,
+ * which is required for @Observed annotations to generate trace spans.
+ */
+@SpringBootTest
+@Testcontainers
+class ObservabilityConfigTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        // Disable OTLP export so missing Jaeger does not break context startup
+        registry.add("management.otlp.tracing.endpoint", () -> "http://localhost:14317");
+    }
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void observedAspect_beanExistsInContext() {
+        // GIVEN / WHEN — context is already started by @SpringBootTest
+
+        // THEN
+        assertThat(applicationContext.getBean(ObservedAspect.class)).isNotNull();
+    }
+
+    @Test
+    void observedAspect_isSingletonInContext() {
+        // WHEN
+        ObservedAspect bean1 = applicationContext.getBean(ObservedAspect.class);
+        ObservedAspect bean2 = applicationContext.getBean(ObservedAspect.class);
+
+        // THEN — Spring default scope is singleton
+        assertThat(bean1).isSameAs(bean2);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/AgentMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/AgentMetricsTest.java
@@ -1,0 +1,37 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentMetricsTest {
+
+    @Test
+    void recordQuery_incrementsCounter() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AgentMetrics metrics = new AgentMetrics(registry);
+
+        // WHEN
+        metrics.recordQuery();
+
+        // THEN
+        assertThat(registry.counter("agent_queries_total").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordQuery_calledThreeTimes_counterIsThree() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AgentMetrics metrics = new AgentMetrics(registry);
+
+        // WHEN
+        metrics.recordQuery();
+        metrics.recordQuery();
+        metrics.recordQuery();
+
+        // THEN
+        assertThat(registry.counter("agent_queries_total").count()).isEqualTo(3.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/CatalogErrorMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/CatalogErrorMetricsTest.java
@@ -1,0 +1,57 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogErrorMetricsTest {
+
+    @Test
+    void recordError_incrementsCounterWithErrorTypeTag() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        CatalogErrorMetrics metrics = new CatalogErrorMetrics(registry);
+
+        // WHEN
+        metrics.recordError("RuntimeException");
+
+        // THEN
+        assertThat(registry.counter("catalog_errors_total", "errorType", "RuntimeException").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void recordError_differentErrorTypes_countersAreIndependent() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        CatalogErrorMetrics metrics = new CatalogErrorMetrics(registry);
+
+        // WHEN
+        metrics.recordError("RuntimeException");
+        metrics.recordError("RuntimeException");
+        metrics.recordError("IllegalArgumentException");
+
+        // THEN
+        assertThat(registry.counter("catalog_errors_total", "errorType", "RuntimeException").count())
+                .isEqualTo(2.0);
+        assertThat(registry.counter("catalog_errors_total", "errorType", "IllegalArgumentException").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void recordError_sameType_accumulatesCount() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        CatalogErrorMetrics metrics = new CatalogErrorMetrics(registry);
+
+        // WHEN
+        metrics.recordError("TariffNotFoundException");
+        metrics.recordError("TariffNotFoundException");
+        metrics.recordError("TariffNotFoundException");
+
+        // THEN
+        assertThat(registry.counter("catalog_errors_total", "errorType", "TariffNotFoundException").count())
+                .isEqualTo(3.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/FolioMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/FolioMetricsTest.java
@@ -1,0 +1,36 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FolioMetricsTest {
+
+    @Test
+    void recordFolioGenerated_incrementsCounter() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        FolioMetrics metrics = new FolioMetrics(registry);
+
+        // WHEN
+        metrics.recordFolioGenerated();
+
+        // THEN
+        assertThat(registry.counter("folios_generated_total").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordFolioGenerated_calledTwice_counterIsTwo() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        FolioMetrics metrics = new FolioMetrics(registry);
+
+        // WHEN
+        metrics.recordFolioGenerated();
+        metrics.recordFolioGenerated();
+
+        // THEN
+        assertThat(registry.counter("folios_generated_total").count()).isEqualTo(2.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/SubscriberMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/SubscriberMetricsTest.java
@@ -1,0 +1,36 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriberMetricsTest {
+
+    @Test
+    void recordQuery_incrementsCounter() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SubscriberMetrics metrics = new SubscriberMetrics(registry);
+
+        // WHEN
+        metrics.recordQuery();
+
+        // THEN
+        assertThat(registry.counter("subscriber_queries_total").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordQuery_calledTwice_counterIsTwo() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SubscriberMetrics metrics = new SubscriberMetrics(registry);
+
+        // WHEN
+        metrics.recordQuery();
+        metrics.recordQuery();
+
+        // THEN
+        assertThat(registry.counter("subscriber_queries_total").count()).isEqualTo(2.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/TariffMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/TariffMetricsTest.java
@@ -1,0 +1,57 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for TariffMetrics.
+ *
+ * Domain adaptation note: Tariffs is a single-row catalog with no fireKey field.
+ * tariff_lookups_total and tariff_lookup_duration_seconds are implemented without
+ * a fireKey tag — see TariffMetrics for full justification.
+ */
+class TariffMetricsTest {
+
+    @Test
+    void recordLookup_incrementsCounter() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        TariffMetrics metrics = new TariffMetrics(registry);
+
+        // WHEN
+        metrics.recordLookup();
+
+        // THEN
+        assertThat(registry.counter("tariff_lookups_total").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordLookup_calledTwice_counterIsTwo() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        TariffMetrics metrics = new TariffMetrics(registry);
+
+        // WHEN
+        metrics.recordLookup();
+        metrics.recordLookup();
+
+        // THEN
+        assertThat(registry.counter("tariff_lookups_total").count()).isEqualTo(2.0);
+    }
+
+    @Test
+    void startAndStopTimer_recordsDuration() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        TariffMetrics metrics = new TariffMetrics(registry);
+
+        // WHEN
+        var sample = metrics.startTimer();
+        metrics.stopTimer(sample);
+
+        // THEN — timer must have recorded exactly 1 observation
+        assertThat(registry.timer("tariff_lookup_duration_seconds").count()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/ZipCodeMetricsTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/shared/infrastructure/metrics/ZipCodeMetricsTest.java
@@ -1,0 +1,51 @@
+package com.sofka.insurancequoter.core.shared.infrastructure.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ZipCodeMetricsTest {
+
+    @Test
+    void recordLookup_found_incrementsCounterWithTagTrue() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ZipCodeMetrics metrics = new ZipCodeMetrics(registry);
+
+        // WHEN
+        metrics.recordLookup(true);
+
+        // THEN
+        assertThat(registry.counter("zipcode_lookups_total", "found", "true").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordLookup_notFound_incrementsCounterWithTagFalse() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ZipCodeMetrics metrics = new ZipCodeMetrics(registry);
+
+        // WHEN
+        metrics.recordLookup(false);
+
+        // THEN
+        assertThat(registry.counter("zipcode_lookups_total", "found", "false").count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordLookup_foundAndNotFound_tagsAreIndependent() {
+        // GIVEN
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ZipCodeMetrics metrics = new ZipCodeMetrics(registry);
+
+        // WHEN
+        metrics.recordLookup(true);
+        metrics.recordLookup(true);
+        metrics.recordLookup(false);
+
+        // THEN
+        assertThat(registry.counter("zipcode_lookups_total", "found", "true").count()).isEqualTo(2.0);
+        assertThat(registry.counter("zipcode_lookups_total", "found", "false").count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/sofka/insurancequoter/core/subscriber/infrastructure/adapter/in/rest/SubscriberControllerTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/subscriber/infrastructure/adapter/in/rest/SubscriberControllerTest.java
@@ -1,5 +1,6 @@
 package com.sofka.insurancequoter.core.subscriber.infrastructure.adapter.in.rest;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.SubscriberMetrics;
 import com.sofka.insurancequoter.core.subscriber.domain.model.Subscriber;
 import com.sofka.insurancequoter.core.subscriber.domain.port.in.GetSubscribersUseCase;
 import com.sofka.insurancequoter.core.subscriber.infrastructure.adapter.in.rest.dto.SubscriberDto;
@@ -26,6 +27,9 @@ class SubscriberControllerTest {
 
     @Mock
     private SubscriberRestMapper subscriberRestMapper;
+
+    @Mock
+    private SubscriberMetrics subscriberMetrics;
 
     @InjectMocks
     private SubscriberController controller;

--- a/src/test/java/com/sofka/insurancequoter/core/tariff/application/usecase/GetTariffsUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/tariff/application/usecase/GetTariffsUseCaseImplTest.java
@@ -1,8 +1,10 @@
 package com.sofka.insurancequoter.core.tariff.application.usecase;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.TariffMetrics;
 import com.sofka.insurancequoter.core.tariff.domain.exception.TariffNotFoundException;
 import com.sofka.insurancequoter.core.tariff.domain.model.Tariffs;
 import com.sofka.insurancequoter.core.tariff.domain.port.out.TariffRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +35,9 @@ class GetTariffsUseCaseImplTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new GetTariffsUseCaseImpl(tariffRepository);
+        // TariffMetrics uses a real SimpleMeterRegistry — no mocking needed for infrastructure
+        TariffMetrics tariffMetrics = new TariffMetrics(new SimpleMeterRegistry());
+        useCase = new GetTariffsUseCaseImpl(tariffRepository, tariffMetrics);
     }
 
     @Test

--- a/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImplTest.java
+++ b/src/test/java/com/sofka/insurancequoter/core/zipcode/application/usecase/GetZipCodeUseCaseImplTest.java
@@ -1,8 +1,10 @@
 package com.sofka.insurancequoter.core.zipcode.application.usecase;
 
+import com.sofka.insurancequoter.core.shared.infrastructure.metrics.ZipCodeMetrics;
 import com.sofka.insurancequoter.core.zipcode.domain.exception.ZipCodeNotFoundException;
 import com.sofka.insurancequoter.core.zipcode.domain.model.ZipCode;
 import com.sofka.insurancequoter.core.zipcode.domain.port.out.ZipCodeRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +28,9 @@ class GetZipCodeUseCaseImplTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new GetZipCodeUseCaseImpl(zipCodeRepository);
+        // ZipCodeMetrics uses a real SimpleMeterRegistry — no mocking needed for infrastructure
+        ZipCodeMetrics zipCodeMetrics = new ZipCodeMetrics(new SimpleMeterRegistry());
+        useCase = new GetZipCodeUseCaseImpl(zipCodeRepository, zipCodeMetrics);
     }
 
     @Test


### PR DESCRIPTION
## Release v1.1.0

### Incluye
- **SPEC-009**: Observabilidad completa para `plataforma-core-ohs`
  - Logs estructurados JSON con `traceId`/`spanId` (LogstashEncoder)
  - Métricas Prometheus: 7 métricas custom de negocio + JVM + HTTP + HikariCP
  - Trazas distribuidas: propagación W3C `traceparent` + `@Observed` en 10 use cases + export OTLP a Jaeger
  - Docker Compose: Jaeger, Prometheus (:9091), Grafana (:3001)

### Tests
139/139 verdes

### PR de origen
#223 (feature → develop)