### PR TITLE
fix(observability): replace deprecated management.otlp.tracing.* properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,8 +36,9 @@ management.metrics.tags.environment=${spring.profiles.active:local}
 
 # Tracing — OTLP to Jaeger (HTTP/Protobuf)
 management.tracing.sampling.probability=1.0
-management.otlp.tracing.endpoint=http://localhost:4318/v1/traces
-management.otlp.tracing.compression=gzip
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+management.opentelemetry.tracing.export.otlp.compression=gzip
+management.opentelemetry.resource-attributes.service.name=${spring.application.name}
 # Disable OTLP metrics export — Jaeger does not support /v1/metrics; Prometheus is used instead
 management.otlp.metrics.export.enabled=false
 


### PR DESCRIPTION
## Fix

`management.otlp.tracing.endpoint` y `management.otlp.tracing.compression` están marcadas como **deprecated** en SB4 (`OtlpTracingProperties` usa el prefijo `management.opentelemetry.tracing.export.otlp.*`).

Missed en PR #226 — commit llegó a `release/v1.2.0` después del merge.

## Cambios
- `management.otlp.tracing.endpoint` → `management.opentelemetry.tracing.export.otlp.endpoint`
- `management.otlp.tracing.compression` → `management.opentelemetry.tracing.export.otlp.compression`
- Añade `management.opentelemetry.resource-attributes.service.name`

## Verificado
- Tests pasan (BUILD SUCCESSFUL)